### PR TITLE
Add persistent settings with UI integration

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,13 +1,16 @@
 import sys
 from PyQt6 import QtWidgets
 from ui_main import Ui_MainWindow
+from settings import AppSettings
 
 
 def main() -> None:
     app = QtWidgets.QApplication(sys.argv)
     window = QtWidgets.QMainWindow()
+    settings = AppSettings.load()
     ui = Ui_MainWindow()
-    ui.setupUi(window)
+    ui.setupUi(window, settings)
+    app.aboutToQuit.connect(settings.save)
     window.show()
     sys.exit(app.exec())
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,0 +1,108 @@
+
+"""Application settings management."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+import json
+
+from PyQt6 import QtWidgets
+
+
+@dataclass
+class AppSettings:
+    """Persistent application settings.
+
+    Parameters
+    ----------
+    project_path:
+        Path to the project or files being processed.
+    api_key:
+        Key for accessing external translation services.
+    model:
+        Identifier of the LLM or translation model in use.
+    machine_check:
+        Whether machine translation verification is enabled.
+    """
+
+    project_path: str = ""
+    api_key: str = ""
+    model: str = ""
+    machine_check: bool = False
+    _file: Path = field(default=Path("settings.json"), repr=False)
+
+    # --- persistence -------------------------------------------------
+    def save(self, file: Path | str | None = None) -> None:
+        """Save settings to *file* in JSON format."""
+
+        file_path = Path(file) if file else self._file
+        data = {
+            "project_path": self.project_path,
+            "api_key": self.api_key,
+            "model": self.model,
+            "machine_check": self.machine_check,
+        }
+        file_path.write_text(
+            json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        self._file = file_path
+
+    @classmethod
+    def load(cls, file: Path | str | None = None) -> "AppSettings":
+        """Load settings from *file* if it exists."""
+
+        file_path = Path(file) if file else Path("settings.json")
+        if file_path.exists():
+            data = json.loads(file_path.read_text(encoding="utf-8"))
+            obj = cls(**data)
+        else:
+            obj = cls()
+        obj._file = file_path
+        return obj
+
+
+class SettingsDialog(QtWidgets.QDialog):
+    """Simple dialog allowing the user to edit settings."""
+
+    def __init__(self, settings: AppSettings, parent: QtWidgets.QWidget | None = None):
+        super().__init__(parent)
+        self.setWindowTitle("Настройки")
+        self.settings = settings
+
+        layout = QtWidgets.QFormLayout(self)
+
+        self.path_edit = QtWidgets.QLineEdit(settings.project_path)
+        self.api_key_edit = QtWidgets.QLineEdit(settings.api_key)
+
+        self.model_combo = QtWidgets.QComboBox()
+        self.model_combo.addItems(["gpt-4", "gpt-3.5", "custom"])
+        if settings.model:
+            index = self.model_combo.findText(settings.model)
+            if index != -1:
+                self.model_combo.setCurrentIndex(index)
+
+        self.machine_check_box = QtWidgets.QCheckBox()
+        self.machine_check_box.setChecked(settings.machine_check)
+
+        layout.addRow("Путь", self.path_edit)
+        layout.addRow("API ключ", self.api_key_edit)
+        layout.addRow("Модель", self.model_combo)
+        layout.addRow("Машинная проверка", self.machine_check_box)
+
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addRow(buttons)
+
+    # --- Qt overrides ------------------------------------------------
+    def accept(self) -> None:  # type: ignore[override]
+        self.settings.project_path = self.path_edit.text()
+        self.settings.api_key = self.api_key_edit.text()
+        self.settings.model = self.model_combo.currentText()
+        self.settings.machine_check = self.machine_check_box.isChecked()
+        self.settings.save()
+        super().accept()

--- a/app/ui_main.py
+++ b/app/ui_main.py
@@ -5,18 +5,28 @@ from __future__ import annotations
 from PyQt6 import QtCore, QtGui, QtWidgets
 
 import styles
+from settings import AppSettings, SettingsDialog
 
 
 class Ui_MainWindow(object):
-    def setupUi(self, MainWindow):
+    def setupUi(self, MainWindow, settings: AppSettings | None = None):
         MainWindow.setObjectName("MainWindow")
         MainWindow.resize(800, 600)
         styles.init()
+
+        self.settings = settings or AppSettings.load()
 
         self.centralwidget = QtWidgets.QWidget(parent=MainWindow)
         MainWindow.setCentralWidget(self.centralwidget)
 
         self.main_layout = QtWidgets.QVBoxLayout(self.centralwidget)
+
+        # Menu bar
+        self.menu_bar = MainWindow.menuBar()
+        self.settings_menu = self.menu_bar.addMenu("")
+        self.settings_action = QtGui.QAction(parent=MainWindow)
+        self.settings_menu.addAction(self.settings_action)
+        self.settings_action.triggered.connect(self._open_settings)
 
         # Navigation bar
         self.nav_layout = QtWidgets.QHBoxLayout()
@@ -143,6 +153,10 @@ class Ui_MainWindow(object):
         self._start_timer()
         self.translation_counter.setText(str(len(self.translation_edit.toPlainText())))
 
+    def _open_settings(self) -> None:
+        dialog = SettingsDialog(self.settings, self.centralwidget)
+        dialog.exec()
+
     # --- translations -----------------------------------------------------
     def retranslateUi(self, MainWindow):
         _translate = QtCore.QCoreApplication.translate
@@ -152,4 +166,6 @@ class Ui_MainWindow(object):
         self.original_label.setText(_translate("MainWindow", "Оригинал"))
         self.translation_label.setText(_translate("MainWindow", "Перевод"))
         self.mini_prompt_label.setText(_translate("MainWindow", "Мини-промпт"))
+        self.settings_menu.setTitle(_translate("MainWindow", "Настройки"))
+        self.settings_action.setText(_translate("MainWindow", "Параметры…"))
 


### PR DESCRIPTION
## Summary
- add `AppSettings` dataclass with JSON load/save helpers
- provide `SettingsDialog` for editing project path, API key, model and machine check
- integrate settings into main window and ensure persistence on app exit

## Testing
- `python -m py_compile app/*.py app/services/*.py app/models/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689c4dbf5e1083328a274bd77aff369e