### PR TITLE
Implement translation model interfaces

### DIFF
--- a/app/models/deepl.py
+++ b/app/models/deepl.py
@@ -1,0 +1,80 @@
+"""Client for interacting with the DeepL translation API."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+import json
+from urllib import error, parse, request
+
+from settings import AppSettings
+
+
+class DeepLTranslator:
+    """Simple wrapper around the DeepL HTTP API.
+
+    Parameters
+    ----------
+    api_key:
+        Optional API key. If not provided, the key is loaded from
+        :class:`settings.AppSettings`.
+    """
+
+    #: Endpoint for the free DeepL API tier. The user may need to change this
+    #: to ``api.deepl.com`` for a paid subscription.
+    BASE_URL = "https://api-free.deepl.com/v2/translate"
+
+    def __init__(self, api_key: Optional[str] = None) -> None:
+        settings = AppSettings.load()
+        self.api_key = api_key or settings.api_key
+        if not self.api_key:
+            raise ValueError("DeepL API key not found in settings")
+
+    # ------------------------------------------------------------------
+    def translate(
+        self,
+        text: str,
+        prompt: str = "",
+        glossary: Optional[Dict[str, str]] = None,
+        target_lang: str = "EN",
+        source_lang: Optional[str] = None,
+    ) -> str:
+        """Translate *text* using DeepL.
+
+        Parameters
+        ----------
+        text:
+            Source text to translate.
+        prompt:
+            Ignored by DeepL but kept for API consistency.
+        glossary:
+            Glossary terms. DeepL's API requires a separate glossary feature,
+            which is not implemented here; entries are therefore ignored and
+            kept solely for interface compatibility.
+        target_lang:
+            Target language code (default ``"EN"``).
+        source_lang:
+            Optional source language code.
+        """
+
+        params: Dict[str, str] = {"text": text, "target_lang": target_lang}
+        if source_lang:
+            params["source_lang"] = source_lang
+
+        data = parse.urlencode(params).encode("utf-8")
+        headers = {"Authorization": f"DeepL-Auth-Key {self.api_key}"}
+        req = request.Request(self.BASE_URL, data=data, headers=headers)
+
+        try:
+            with request.urlopen(req) as resp:
+                payload = json.loads(resp.read().decode("utf-8"))
+        except error.HTTPError as exc:  # pragma: no cover - network/IO safety
+            message = exc.read().decode("utf-8", errors="ignore")
+            raise RuntimeError(f"DeepL API error: {message}") from exc
+        except error.URLError as exc:  # pragma: no cover - network/IO safety
+            raise RuntimeError(f"DeepL connection error: {exc.reason}") from exc
+
+        try:
+            return payload["translations"][0]["text"]
+        except (KeyError, IndexError) as exc:
+            raise RuntimeError("Unexpected response format from DeepL") from exc
+

--- a/app/models/gemini.py
+++ b/app/models/gemini.py
@@ -1,0 +1,70 @@
+"""Client for the Google Gemini API."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+import json
+from urllib import error, request
+
+from settings import AppSettings
+
+
+class GeminiTranslator:
+    """Translate text using Google's Gemini models."""
+
+    BASE_URL = (
+        "https://generativelanguage.googleapis.com/v1beta/models/"
+        "gemini-pro:generateContent"
+    )
+
+    def __init__(self, api_key: Optional[str] = None) -> None:
+        settings = AppSettings.load()
+        self.api_key = api_key or settings.api_key
+        if not self.api_key:
+            raise ValueError("Gemini API key not found in settings")
+
+    # ------------------------------------------------------------------
+    def translate(
+        self,
+        text: str,
+        prompt: str = "",
+        glossary: Optional[Dict[str, str]] = None,
+    ) -> str:
+        """Translate *text* using Gemini.
+
+        The method sends a single prompt containing the optional *prompt*,
+        formatted *glossary* terms and the *text* itself. Errors from the
+        underlying HTTP API are re-raised as :class:`RuntimeError`.
+        """
+
+        parts = []
+        if prompt:
+            parts.append(prompt)
+        if glossary:
+            glossary_text = "\n".join(f"{k}: {v}" for k, v in glossary.items())
+            parts.append("Glossary:\n" + glossary_text)
+        parts.append(text)
+        full_prompt = "\n\n".join(parts)
+
+        body = {"contents": [{"parts": [{"text": full_prompt}]}]}
+        url = f"{self.BASE_URL}?key={self.api_key}"
+        req = request.Request(
+            url,
+            data=json.dumps(body).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+        )
+
+        try:
+            with request.urlopen(req) as resp:
+                payload = json.loads(resp.read().decode("utf-8"))
+        except error.HTTPError as exc:  # pragma: no cover - network/IO safety
+            message = exc.read().decode("utf-8", errors="ignore")
+            raise RuntimeError(f"Gemini API error: {message}") from exc
+        except error.URLError as exc:  # pragma: no cover - network/IO safety
+            raise RuntimeError(f"Gemini connection error: {exc.reason}") from exc
+
+        try:
+            return payload["candidates"][0]["content"]["parts"][0]["text"]
+        except (KeyError, IndexError) as exc:
+            raise RuntimeError("Unexpected response format from Gemini") from exc
+

--- a/app/models/grok.py
+++ b/app/models/grok.py
@@ -1,0 +1,73 @@
+"""Client for the xAI Grok API."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+import json
+from urllib import error, request
+
+from settings import AppSettings
+
+
+class GrokTranslator:
+    """Translate text using xAI's Grok model."""
+
+    BASE_URL = "https://api.x.ai/v1/chat/completions"
+    DEFAULT_MODEL = "grok-beta"
+
+    def __init__(self, api_key: Optional[str] = None, model: str | None = None) -> None:
+        settings = AppSettings.load()
+        self.api_key = api_key or settings.api_key
+        if not self.api_key:
+            raise ValueError("Grok API key not found in settings")
+        self.model = model or self.DEFAULT_MODEL
+
+    # ------------------------------------------------------------------
+    def translate(
+        self,
+        text: str,
+        prompt: str = "",
+        glossary: Optional[Dict[str, str]] = None,
+    ) -> str:
+        """Translate *text* using Grok.
+
+        The *prompt* and *glossary* are merged into a system instruction sent
+        alongside the user's text. Any network or API related errors are
+        propagated as :class:`RuntimeError`.
+        """
+
+        system_parts = [prompt] if prompt else []
+        if glossary:
+            glossary_text = "\n".join(f"{k}: {v}" for k, v in glossary.items())
+            system_parts.append("Glossary:\n" + glossary_text)
+        system_message = "\n\n".join(system_parts) if system_parts else ""
+
+        body = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": system_message},
+                {"role": "user", "content": text},
+            ],
+        }
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        req = request.Request(
+            self.BASE_URL, data=json.dumps(body).encode("utf-8"), headers=headers
+        )
+
+        try:
+            with request.urlopen(req) as resp:
+                payload = json.loads(resp.read().decode("utf-8"))
+        except error.HTTPError as exc:  # pragma: no cover - network/IO safety
+            message = exc.read().decode("utf-8", errors="ignore")
+            raise RuntimeError(f"Grok API error: {message}") from exc
+        except error.URLError as exc:  # pragma: no cover - network/IO safety
+            raise RuntimeError(f"Grok connection error: {exc.reason}") from exc
+
+        try:
+            return payload["choices"][0]["message"]["content"].strip()
+        except (KeyError, IndexError) as exc:
+            raise RuntimeError("Unexpected response format from Grok") from exc
+

--- a/app/models/qwen.py
+++ b/app/models/qwen.py
@@ -1,0 +1,72 @@
+"""Client for the Qwen (Alibaba Cloud) API."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+import json
+from urllib import error, request
+
+from settings import AppSettings
+
+
+class QwenTranslator:
+    """Translate text using the Qwen model."""
+
+    BASE_URL = "https://api.qwen.ai/v1/chat/completions"
+    DEFAULT_MODEL = "qwen-turbo"
+
+    def __init__(self, api_key: Optional[str] = None, model: str | None = None) -> None:
+        settings = AppSettings.load()
+        self.api_key = api_key or settings.api_key
+        if not self.api_key:
+            raise ValueError("Qwen API key not found in settings")
+        self.model = model or self.DEFAULT_MODEL
+
+    # ------------------------------------------------------------------
+    def translate(
+        self,
+        text: str,
+        prompt: str = "",
+        glossary: Optional[Dict[str, str]] = None,
+    ) -> str:
+        """Translate *text* using Qwen.
+
+        ``prompt`` and ``glossary`` are combined into the system message.
+        Network or API related errors are raised as :class:`RuntimeError`.
+        """
+
+        system_parts = [prompt] if prompt else []
+        if glossary:
+            glossary_text = "\n".join(f"{k}: {v}" for k, v in glossary.items())
+            system_parts.append("Glossary:\n" + glossary_text)
+        system_message = "\n\n".join(system_parts) if system_parts else ""
+
+        body = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": system_message},
+                {"role": "user", "content": text},
+            ],
+        }
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        req = request.Request(
+            self.BASE_URL, data=json.dumps(body).encode("utf-8"), headers=headers
+        )
+
+        try:
+            with request.urlopen(req) as resp:
+                payload = json.loads(resp.read().decode("utf-8"))
+        except error.HTTPError as exc:  # pragma: no cover - network/IO safety
+            message = exc.read().decode("utf-8", errors="ignore")
+            raise RuntimeError(f"Qwen API error: {message}") from exc
+        except error.URLError as exc:  # pragma: no cover - network/IO safety
+            raise RuntimeError(f"Qwen connection error: {exc.reason}") from exc
+
+        try:
+            return payload["choices"][0]["message"]["content"].strip()
+        except (KeyError, IndexError) as exc:
+            raise RuntimeError("Unexpected response format from Qwen") from exc
+


### PR DESCRIPTION
## Summary
- add GeminiTranslator, DeepLTranslator, GrokTranslator, and QwenTranslator with shared translate interface
- load API keys from settings and raise clear errors on failure
- handle HTTP issues via exceptions for robustness

## Testing
- `python -m py_compile app/models/deepl.py app/models/gemini.py app/models/grok.py app/models/qwen.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689c521917f483329903d347f18ec5b6