### PR TITLE
Add batch translation workflow and request rate limiting

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,14 +4,15 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from queue import Queue
 from typing import Dict
 
 from PyQt6 import QtGui, QtWidgets
 
 from models import get_translator
-from services.files import iter_docx_files, load_docx, save_docx
+from services.files import enqueue_chapters, iter_docx_files, load_docx, save_docx
 from services.versioning import check_for_updates
-from services.workers import ModelWorker
+from services.workers import DEFAULT_RATE_LIMITER, ModelWorker
 from ui_main import Ui_MainWindow
 from settings import AppSettings
 
@@ -25,6 +26,7 @@ class MainController:
         self.settings = settings
         self.chapters: list[Path] = []
         self.worker: ModelWorker | None = None
+        self.batch_queue: Queue[Path] | None = None
 
         self._init_ui()
         self._load_chapter_list()
@@ -32,10 +34,15 @@ class MainController:
     # ------------------------------------------------------------------
     # UI setup and shortcuts
     def _init_ui(self) -> None:
-        # translate button
+        # translate buttons
+        self.buttons_layout = QtWidgets.QHBoxLayout()
         self.translate_btn = QtWidgets.QPushButton("Перевести", parent=self.ui.translation_widget)
-        self.ui.translation_layout.insertWidget(0, self.translate_btn)
+        self.batch_btn = QtWidgets.QPushButton("Перевести все", parent=self.ui.translation_widget)
+        self.buttons_layout.addWidget(self.translate_btn)
+        self.buttons_layout.addWidget(self.batch_btn)
+        self.ui.translation_layout.insertLayout(0, self.buttons_layout)
         self.translate_btn.clicked.connect(self.translate)
+        self.batch_btn.clicked.connect(self.batch_translate)
 
         # chapter navigation
         self.ui.prev_btn.clicked.connect(self.prev_chapter)
@@ -107,7 +114,13 @@ class MainController:
             return
 
         self.translate_btn.setEnabled(False)
-        worker = ModelWorker(model, text, prompt=prompt, glossary=glossary)
+        worker = ModelWorker(
+            model,
+            text,
+            prompt=prompt,
+            glossary=glossary,
+            rate_limiter=DEFAULT_RATE_LIMITER,
+        )
         worker.finished.connect(self._on_translation_finished)
         worker.error.connect(self._on_translation_error)
         worker.start()
@@ -120,6 +133,58 @@ class MainController:
     def _on_translation_error(self, exc: Exception) -> None:
         self.translate_btn.setEnabled(True)
         QtWidgets.QMessageBox.critical(self.window, "Ошибка", str(exc))
+
+    # ------------------------------------------------------------------
+    # Batch translation
+    def batch_translate(self) -> None:
+        path = self.settings.project_path
+        if not path:
+            return
+        queue: Queue[Path] = Queue()
+        self.chapters = enqueue_chapters(Path(path), queue)
+        if not self.chapters:
+            return
+        self.batch_queue = queue
+        self.batch_btn.setEnabled(False)
+        self.translate_btn.setEnabled(False)
+        self._process_queue()
+
+    def _process_queue(self) -> None:
+        if not self.batch_queue or self.batch_queue.empty():
+            self.batch_btn.setEnabled(True)
+            self.translate_btn.setEnabled(True)
+            return
+        src = self.batch_queue.get()
+        text = load_docx(src)
+        prompt = self.ui.mini_prompt_edit.toPlainText().strip()
+        glossary = self._parse_glossary()
+        try:
+            model = get_translator(self.settings.model or "gemini")
+        except Exception as exc:  # pragma: no cover - settings misuse
+            QtWidgets.QMessageBox.critical(self.window, "Ошибка", str(exc))
+            self._process_queue()
+            return
+        worker = ModelWorker(
+            model,
+            text,
+            prompt=prompt,
+            glossary=glossary,
+            rate_limiter=DEFAULT_RATE_LIMITER,
+        )
+        worker.finished.connect(lambda result, p=src: self._on_batch_translation_finished(p, result))
+        worker.error.connect(self._on_batch_translation_error)
+        worker.start()
+        self.worker = worker
+
+    def _on_batch_translation_finished(self, src: Path, result: str) -> None:
+        self.ui.translation_edit.setPlainText(result)
+        out_path = src.with_name(src.stem + "_translated.docx")
+        save_docx(result, out_path)
+        self._process_queue()
+
+    def _on_batch_translation_error(self, exc: Exception) -> None:
+        QtWidgets.QMessageBox.critical(self.window, "Ошибка", str(exc))
+        self._process_queue()
 
     # ------------------------------------------------------------------
     def save_translation(self) -> None:

--- a/app/services/files.py
+++ b/app/services/files.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Iterable
+from queue import Queue
 import xml.etree.ElementTree as ET
 import zipfile
 import json
@@ -24,6 +25,20 @@ def iter_docx_files(folder: Path | str) -> Iterable[Path]:
 
     root = Path(folder)
     yield from root.rglob("*.docx")
+
+
+def enqueue_chapters(folder: Path | str, queue: Queue[Path]) -> list[Path]:
+    """Scan *folder* for chapters and enqueue them into *queue*.
+
+    Returns the list of discovered chapter paths. The function simply
+    traverses the folder using :func:`iter_docx_files` and puts each file
+    into the provided queue for later processing by workers.
+    """
+
+    files = sorted(iter_docx_files(folder))
+    for file in files:
+        queue.put(file)
+    return files
 
 
 # ---------------------------------------------------------------------------

--- a/app/services/workers.py
+++ b/app/services/workers.py
@@ -4,7 +4,29 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
+import threading
+import time
+
 from PyQt6 import QtCore
+
+
+class RateLimiter:
+    """Simple thread-safe rate limiter."""
+
+    def __init__(self, rps: float) -> None:
+        self.interval = 1.0 / rps if rps > 0 else 0.0
+        self.lock = threading.Lock()
+        self.last_call = 0.0
+
+    def wait(self) -> None:
+        """Block until the next call is allowed."""
+
+        with self.lock:
+            now = time.perf_counter()
+            delay = self.last_call + self.interval - now
+            if delay > 0:
+                time.sleep(delay)
+            self.last_call = time.perf_counter()
 
 
 class Worker(QtCore.QThread):
@@ -13,14 +35,23 @@ class Worker(QtCore.QThread):
     finished = QtCore.pyqtSignal(object)
     error = QtCore.pyqtSignal(Exception)
 
-    def __init__(self, func: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        func: Callable[..., Any],
+        *args: Any,
+        rate_limiter: RateLimiter | None = None,
+        **kwargs: Any,
+    ) -> None:
         super().__init__()
         self.func = func
         self.args = args
         self.kwargs = kwargs
+        self.rate_limiter = rate_limiter
 
     def run(self) -> None:  # type: ignore[override]
         try:
+            if self.rate_limiter is not None:
+                self.rate_limiter.wait()
             result = self.func(*self.args, **self.kwargs)
         except Exception as exc:  # pragma: no cover - network/IO safety
             self.error.emit(exc)
@@ -31,5 +62,15 @@ class Worker(QtCore.QThread):
 class ModelWorker(Worker):
     """Worker executing ``model.translate`` in the background."""
 
-    def __init__(self, model: Any, text: str, **kwargs: Any) -> None:
-        super().__init__(model.translate, text, **kwargs)
+    def __init__(
+        self,
+        model: Any,
+        text: str,
+        rate_limiter: RateLimiter | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(model.translate, text, rate_limiter=rate_limiter, **kwargs)
+
+
+# Default limiter allowing one request per second
+DEFAULT_RATE_LIMITER = RateLimiter(1.0)


### PR DESCRIPTION
## Summary
- enqueue chapter files and create tasks for batch translation
- enforce a simple RPS limit for background workers
- add UI controls and logic to run batch translation over all chapters

## Testing
- `python -m py_compile app/main.py app/services/files.py app/services/workers.py`


------
https://chatgpt.com/codex/tasks/task_e_689c5bc4dcf08332a16dc2f3f42efc5b