### PR TITLE
Add translation statistics and export reports

### DIFF
--- a/app/services/files.py
+++ b/app/services/files.py
@@ -134,3 +134,40 @@ def append_version(text: str, path: Path | str) -> list[dict]:
     versions.append({"timestamp": datetime.utcnow().isoformat(), "text": text})
     save_versions(versions, path)
     return versions
+
+
+# ---------------------------------------------------------------------------
+# Statistics handling
+
+def load_stats(path: Path | str) -> list[dict]:
+    """Load translation statistics from *path*.
+
+    Returns an empty list if the file does not exist.
+    """
+
+    file_path = Path(path)
+    if not file_path.exists():
+        return []
+    with file_path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def save_stats(stats: list[dict], path: Path | str) -> None:
+    """Persist statistics *stats* to *path* as JSON."""
+
+    file_path = Path(path)
+    with file_path.open("w", encoding="utf-8") as fh:
+        json.dump(stats, fh, ensure_ascii=False, indent=2)
+
+
+def append_stat(stat: dict, path: Path | str) -> list[dict]:
+    """Append a new statistics entry to *path*.
+
+    The function loads existing stats, appends *stat* and writes the
+    updated list back to disk. The updated list is returned.
+    """
+
+    stats = load_stats(path)
+    stats.append(stat)
+    save_stats(stats, path)
+    return stats

--- a/app/services/reports.py
+++ b/app/services/reports.py
@@ -1,0 +1,36 @@
+"""Simple report generation utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+import csv
+from html import escape
+
+
+def save_csv(stats: Iterable[dict], path: Path | str) -> None:
+    """Save *stats* to *path* in CSV format."""
+
+    file_path = Path(path)
+    with file_path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=["chapter", "characters", "time"])
+        writer.writeheader()
+        writer.writerows(stats)
+
+
+def save_html(stats: Iterable[dict], path: Path | str) -> None:
+    """Save *stats* to *path* as a minimal HTML table."""
+
+    rows = "".join(
+        f"<tr><td>{escape(str(s.get('chapter', '')))}</td><td>{s.get('characters', '')}</td><td>{s.get('time', '')}</td></tr>"
+        for s in stats
+    )
+    table = (
+        "<table>"
+        "<tr><th>chapter</th><th>characters</th><th>time</th></tr>"
+        f"{rows}"
+        "</table>"
+    )
+    file_path = Path(path)
+    with file_path.open("w", encoding="utf-8") as fh:
+        fh.write("<html><body>" + table + "</body></html>")

--- a/app/ui_main.py
+++ b/app/ui_main.py
@@ -178,6 +178,13 @@ class Ui_MainWindow(object):
         if not self.timer.isActive():
             self.timer.start()
 
+    def reset_timer(self) -> None:
+        """Reset the editing timer."""
+
+        self.timer.stop()
+        self.elapsed = 0
+        self.timer_label.setText("00:00")
+
     def _update_original_counter(self) -> None:
         self._start_timer()
         self.original_counter.setText(str(len(self.original_edit.toPlainText())))


### PR DESCRIPTION
## Summary
- track per-chapter translation stats and persist them
- generate CSV/HTML reports from saved statistics
- add UI button to export reports

## Testing
- `python -m py_compile app/services/files.py app/services/reports.py app/ui_main.py app/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c61eb1234833290ac6de15678087e