### PR TITLE
Add editable glossary management UI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -65,7 +65,7 @@ class MainController:
         QtGui.QShortcut(QtGui.QKeySequence("Ctrl+S"), self.window, activated=self.save_translation)
         QtGui.QShortcut(QtGui.QKeySequence("Alt+Right"), self.window, activated=self.next_chapter)
         QtGui.QShortcut(QtGui.QKeySequence("Alt+Left"), self.window, activated=self.prev_chapter)
-        QtGui.QShortcut(QtGui.QKeySequence("Ctrl+G"), self.window, activated=lambda: self.ui.glossary.setFocus())
+        QtGui.QShortcut(QtGui.QKeySequence("Ctrl+G"), self.window, activated=lambda: self.ui.glossary_table.setFocus())
         QtGui.QShortcut(QtGui.QKeySequence("Ctrl+1"), self.window, activated=lambda: self.ui.original_edit.setFocus())
         QtGui.QShortcut(QtGui.QKeySequence("Ctrl+2"), self.window, activated=lambda: self.ui.translation_edit.setFocus())
         QtGui.QShortcut(QtGui.QKeySequence("Ctrl+3"), self.window, activated=lambda: self.ui.mini_prompt_edit.setFocus())
@@ -110,12 +110,7 @@ class MainController:
     # ------------------------------------------------------------------
     # Translation workflow
     def _parse_glossary(self) -> Dict[str, str]:
-        entries: Dict[str, str] = {}
-        for line in self.ui.glossary.toPlainText().splitlines():
-            if "->" in line:
-                src, dst = line.split("->", 1)
-                entries[src.strip()] = dst.strip()
-        return entries
+        return self.ui.glossary_entries()
 
     def translate(self) -> None:
         text = self.ui.original_edit.toPlainText().strip()

--- a/app/services/glossary.py
+++ b/app/services/glossary.py
@@ -68,3 +68,39 @@ def list_glossaries(folder: Path | str) -> list[Path]:
 
     root = Path(folder)
     return sorted(root.glob("*.json"))
+
+
+def create_glossary(name: str, folder: Path | str) -> Glossary:
+    """Create a new empty glossary with *name* in *folder*.
+
+    The new glossary is written to ``<folder>/<name>.json`` and the
+    corresponding :class:`Glossary` instance is returned.
+    """
+
+    root = Path(folder)
+    root.mkdir(parents=True, exist_ok=True)
+    glossary = Glossary(name=name)
+    path = root / f"{name}.json"
+    glossary.save(path)
+    return glossary
+
+
+def rename_glossary(path: Path | str, new_name: str) -> Path:
+    """Rename the glossary file at *path* to *new_name*.
+
+    Returns the new :class:`Path` of the renamed file.
+    """
+
+    file_path = Path(path)
+    new_path = file_path.with_name(f"{new_name}.json")
+    if file_path.exists():
+        file_path.rename(new_path)
+    return new_path
+
+
+def delete_glossary(path: Path | str) -> None:
+    """Remove the glossary file at *path* if it exists."""
+
+    file_path = Path(path)
+    if file_path.exists():
+        file_path.unlink()


### PR DESCRIPTION
## Summary
- Replace static glossary text box with interactive glossary manager
- Add glossary CRUD helpers and integrate with translation workflow
- Load selected glossary at startup

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c663a082483328b6f58ecf0092998