### PR TITLE
feat: auto-update repository

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -19,7 +19,7 @@ from services.files import (
     save_docx,
 )
 from services.reports import save_csv, save_html
-from services.versioning import check_for_updates
+from services.versioning import check_for_updates, pull_updates
 from services.workers import DEFAULT_RATE_LIMITER, ModelWorker
 from ui_main import Ui_MainWindow
 from settings import AppSettings
@@ -239,7 +239,11 @@ def main() -> None:
     app = QtWidgets.QApplication(sys.argv)
     repo_root = Path(__file__).resolve().parent.parent
     if check_for_updates(repo_root):
-        QtWidgets.QMessageBox.information(None, "Обновление", "Доступны обновления приложения.")
+        success, message = pull_updates(repo_root)
+        if success:
+            QtWidgets.QMessageBox.information(None, "Обновление", "Приложение обновлено до последней версии.")
+        else:
+            QtWidgets.QMessageBox.warning(None, "Обновление", f"Не удалось обновить приложение: {message}")
     window = QtWidgets.QMainWindow()
     settings = AppSettings.load()
     ui = Ui_MainWindow()

--- a/app/services/versioning.py
+++ b/app/services/versioning.py
@@ -68,3 +68,26 @@ def check_for_updates(repo_path: Path) -> bool:
         return "behind" in status.stdout.lower()
     except Exception:
         return False
+
+
+def pull_updates(repo_path: Path) -> tuple[bool, str]:
+    """Attempt to update *repo_path* by pulling from the remote.
+
+    Returns a tuple ``(success, message)`` describing the result.
+    """
+
+    try:
+        result = subprocess.run(
+            ["git", "pull"],
+            cwd=repo_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        message = result.stdout.strip() or "Repository updated successfully."
+        return True, message
+    except subprocess.CalledProcessError as exc:
+        message = exc.stderr.strip() or "git pull failed"
+        return False, message
+    except Exception as exc:  # pragma: no cover - unexpected errors
+        return False, str(exc)


### PR DESCRIPTION
## Summary
- allow application to update itself by running `git pull`
- inform users about update success or failure on startup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c6d930f4483328d60f80d815bc94a