### PR TITLE
Show application version in UI

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,3 @@
+"""Application package metadata."""
+
+__version__ = "0.1.0"

--- a/app/ui_main.py
+++ b/app/ui_main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from PyQt6 import QtCore, QtGui, QtWidgets
 
 import styles
+from . import __version__
 from pathlib import Path
 from services.versioning import VersionManager
 from services.morphology import MorphologyService, MorphologyHighlighter
@@ -22,6 +23,7 @@ from .diff_utils import DiffHighlighter
 
 class Ui_MainWindow(object):
     def setupUi(self, MainWindow, settings: AppSettings | None = None):
+        print(f"Application version: {__version__}")
         MainWindow.setObjectName("MainWindow")
         MainWindow.resize(800, 600)
         styles.init()
@@ -162,6 +164,8 @@ class Ui_MainWindow(object):
         # Status/timer area
         self.status_layout = QtWidgets.QHBoxLayout()
         self.status_layout.addStretch()
+        self.version_label = QtWidgets.QLabel(__version__, parent=self.centralwidget)
+        self.status_layout.addWidget(self.version_label)
         self.timer_label = QtWidgets.QLabel("00:00:00", parent=self.centralwidget)
         self.status_layout.addWidget(self.timer_label)
         self.main_layout.addLayout(self.status_layout)
@@ -172,6 +176,8 @@ class Ui_MainWindow(object):
         self.translation_edit.setFont(base_font)
         self.mini_prompt_edit.setFont(base_font)
         self.glossary_table.setFont(base_font)
+        self.timer_label.setFont(base_font)
+        self.version_label.setFont(base_font)
 
         # Style sheet applying colours
         style_sheet = f"""


### PR DESCRIPTION
## Summary
- define `__version__` in package
- show application version label next to timer
- print application version when `Ui_MainWindow.setupUi` runs

## Testing
- `python -m py_compile app/__init__.py app/ui_main.py`
- `QT_QPA_PLATFORM=offscreen python - <<'PY'
import sys
sys.path.append('/workspace/Perevod4ik')
sys.path.append('/workspace/Perevod4ik/app')
from app.ui_main import Ui_MainWindow
from PyQt6 import QtWidgets
app = QtWidgets.QApplication([])
ui = Ui_MainWindow()
window = QtWidgets.QMainWindow()
ui.setupUi(window)
PY` *(fails: QFontDatabase() not enough arguments)*

------
https://chatgpt.com/codex/tasks/task_e_689c71bf1c348332b9e89c343f692cfb