### PR TITLE
Highlight accent color for focused and hovered inputs

### DIFF
--- a/app/styles.py
+++ b/app/styles.py
@@ -15,6 +15,18 @@ ACCENT_COLOR = "#00E5FF"
 INTER_FONT = "Inter"
 HEADER_FONT = "Cattedrale"
 
+# QSS rule that highlights widgets when hovered or focused
+FOCUS_HOVER_RULE = f"""
+QTextEdit:focus,
+QTextEdit:hover,
+QLineEdit:focus,
+QLineEdit:hover,
+QTableWidget#glossary:focus,
+QTableWidget#glossary:hover {{
+    border: 1px solid {ACCENT_COLOR};
+}}
+""".strip()
+
 
 def init() -> None:
     """Load bundled fonts and expose their family names.

--- a/app/ui_main.py
+++ b/app/ui_main.py
@@ -190,17 +190,21 @@ class Ui_MainWindow(object):
             color: {styles.TEXT_COLOR};
             font-family: {styles.INTER_FONT};
         }}
-        QTextEdit {{
+        QTextEdit,
+        QLineEdit {{
             background-color: {styles.FIELD_BACKGROUND};
             color: {styles.TEXT_COLOR};
+            border: 1px solid transparent;
         }}
         QTableWidget#glossary {{
             background-color: {styles.GLOSSARY_BACKGROUND};
+            border: 1px solid transparent;
         }}
         QLabel#counter {{
             color: rgba(255, 255, 255, 128);
             font-size: 10px;
         }}
+        {styles.FOCUS_HOVER_RULE}
         """
         self.centralwidget.setStyleSheet(style_sheet)
 


### PR DESCRIPTION
## Summary
- add shared QSS rule to accent widgets on hover and focus
- style QTextEdit, QLineEdit, and glossary table using the new rule

## Testing
- `python -m py_compile app/styles.py app/ui_main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c75e1a2948332a8b97313fcd5f5e6