### PR TITLE
feat: extend settings with paths and customization

### DIFF
--- a/app/diff_utils.py
+++ b/app/diff_utils.py
@@ -8,13 +8,23 @@ from PyQt6 import QtGui
 class DiffHighlighter(QtGui.QSyntaxHighlighter):
     """Highlight differences from a baseline text."""
 
-    def __init__(self, document: QtGui.QTextDocument, base: str = "") -> None:
+    def __init__(
+        self,
+        document: QtGui.QTextDocument,
+        base: str = "",
+        color: QtGui.QColor | str | None = None,
+    ) -> None:
         super().__init__(document)
         self._base = base
         self._diff_ranges: list[tuple[int, int]] = []
         self._fmt = QtGui.QTextCharFormat()
-        # Using a subtle yellow background for changed text
-        self._fmt.setBackground(QtGui.QColor(255, 255, 0, 128))
+        self.set_color(color or QtGui.QColor(255, 255, 0, 128))
+
+    def set_color(self, color: QtGui.QColor | str) -> None:
+        if isinstance(color, str):
+            color = QtGui.QColor(color)
+        self._fmt.setBackground(color)
+        self.rehighlight()
 
     def set_base(self, text: str) -> None:
         """Set baseline *text* for future comparisons."""

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,13 +1,11 @@
-
 """Application settings management."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-import json
 
-from PyQt6 import QtWidgets
+from PyQt6 import QtCore, QtGui, QtWidgets
 
 
 @dataclass
@@ -16,67 +14,97 @@ class AppSettings:
 
     Parameters
     ----------
-    project_path:
-        Path to the project or files being processed.
+    original_path:
+        Folder containing original chapters.
+    translation_path:
+        Folder where translated chapters and metadata are stored.
     api_key:
         Key for accessing external translation services.
     model:
         Identifier of the LLM or translation model in use.
     machine_check:
         Whether machine translation verification is enabled.
+    auto_next:
+        Move to the next chapter automatically after saving.
+    highlight_color:
+        Background colour for diff highlighting in ARGB hex format.
     """
 
-    project_path: str = ""
+    original_path: str = ""
+    translation_path: str = ""
     api_key: str = ""
     model: str = ""
     machine_check: bool = False
-    _file: Path = field(default=Path("settings.json"), repr=False)
+    auto_next: bool = False
+    highlight_color: str = "#80ffff00"  # semi-transparent yellow
+    _file: Path = field(default=Path("settings.ini"), repr=False)
 
     # --- persistence -------------------------------------------------
     def save(self, file: Path | str | None = None) -> None:
-        """Save settings to *file* in JSON format."""
+        """Persist settings using :class:`QtCore.QSettings`."""
 
         file_path = Path(file) if file else self._file
-        data = {
-            "project_path": self.project_path,
-            "api_key": self.api_key,
-            "model": self.model,
-            "machine_check": self.machine_check,
-        }
-        file_path.write_text(
-            json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8"
-        )
+        qs = QtCore.QSettings(str(file_path), QtCore.QSettings.Format.IniFormat)
+        qs.setValue("original_path", self.original_path)
+        qs.setValue("translation_path", self.translation_path)
+        qs.setValue("api_key", self.api_key)
+        qs.setValue("model", self.model)
+        qs.setValue("machine_check", self.machine_check)
+        qs.setValue("auto_next", self.auto_next)
+        qs.setValue("highlight_color", self.highlight_color)
+        qs.sync()
         self._file = file_path
 
     @classmethod
     def load(cls, file: Path | str | None = None) -> "AppSettings":
-        """Load settings from *file* if it exists."""
+        """Load settings from a :class:`QtCore.QSettings` store."""
 
-        file_path = Path(file) if file else Path("settings.json")
-        if file_path.exists():
-            data = json.loads(file_path.read_text(encoding="utf-8"))
-            obj = cls(**data)
-        else:
-            obj = cls()
+        file_path = Path(file) if file else Path("settings.ini")
+        qs = QtCore.QSettings(str(file_path), QtCore.QSettings.Format.IniFormat)
+        obj = cls(
+            original_path=qs.value("original_path", "", str),
+            translation_path=qs.value("translation_path", "", str),
+            api_key=qs.value("api_key", "", str),
+            model=qs.value("model", "", str),
+            machine_check=qs.value("machine_check", False, bool),
+            auto_next=qs.value("auto_next", False, bool),
+            highlight_color=qs.value("highlight_color", "#80ffff00", str),
+        )
         obj._file = file_path
         return obj
 
 
 class SettingsDialog(QtWidgets.QDialog):
-    """Simple dialog allowing the user to edit settings."""
+    """Dialog allowing the user to edit application settings."""
 
     def __init__(self, settings: AppSettings, parent: QtWidgets.QWidget | None = None):
         super().__init__(parent)
         self.setWindowTitle("Настройки")
         self.settings = settings
+        self._color = QtGui.QColor(settings.highlight_color)
 
         layout = QtWidgets.QFormLayout(self)
 
-        self.path_edit = QtWidgets.QLineEdit(settings.project_path)
+        # Original folder selector
+        orig_layout = QtWidgets.QHBoxLayout()
+        self.original_edit = QtWidgets.QLineEdit(settings.original_path)
+        orig_btn = QtWidgets.QPushButton("...")
+        orig_btn.clicked.connect(lambda: self._choose_folder(self.original_edit))
+        orig_layout.addWidget(self.original_edit)
+        orig_layout.addWidget(orig_btn)
+
+        # Translation folder selector
+        trans_layout = QtWidgets.QHBoxLayout()
+        self.translation_edit = QtWidgets.QLineEdit(settings.translation_path)
+        trans_btn = QtWidgets.QPushButton("...")
+        trans_btn.clicked.connect(lambda: self._choose_folder(self.translation_edit))
+        trans_layout.addWidget(self.translation_edit)
+        trans_layout.addWidget(trans_btn)
+
         self.api_key_edit = QtWidgets.QLineEdit(settings.api_key)
 
         self.model_combo = QtWidgets.QComboBox()
-        self.model_combo.addItems(["gpt-4", "gpt-3.5", "custom"])
+        self.model_combo.addItems(["gemini", "deepl", "grok", "qwen"])
         if settings.model:
             index = self.model_combo.findText(settings.model)
             if index != -1:
@@ -85,24 +113,59 @@ class SettingsDialog(QtWidgets.QDialog):
         self.machine_check_box = QtWidgets.QCheckBox()
         self.machine_check_box.setChecked(settings.machine_check)
 
-        layout.addRow("Путь", self.path_edit)
+        self.auto_next_box = QtWidgets.QCheckBox()
+        self.auto_next_box.setChecked(settings.auto_next)
+
+        self.color_btn = QtWidgets.QPushButton()
+        self._update_color_btn()
+        self.color_btn.clicked.connect(self._choose_color)
+
+        layout.addRow("Папка оригинала", orig_layout)
+        layout.addRow("Папка перевода", trans_layout)
         layout.addRow("API ключ", self.api_key_edit)
         layout.addRow("Модель", self.model_combo)
         layout.addRow("Машинная проверка", self.machine_check_box)
+        layout.addRow("Следующая глава", self.auto_next_box)
+        layout.addRow("Цвет подсветки", self.color_btn)
 
         buttons = QtWidgets.QDialogButtonBox(
             QtWidgets.QDialogButtonBox.StandardButton.Ok
-            | QtWidgets.QDialogButtonBox.StandardButton.Cancel
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
         )
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
         layout.addRow(buttons)
 
+    # --- internal helpers --------------------------------------------
+    def _choose_folder(self, line_edit: QtWidgets.QLineEdit) -> None:
+        path = QtWidgets.QFileDialog.getExistingDirectory(
+            self, "Выбор папки", line_edit.text()
+        )
+        if path:
+            line_edit.setText(path)
+
+    def _choose_color(self) -> None:
+        color = QtWidgets.QColorDialog.getColor(self._color, self)
+        if color.isValid():
+            self._color = color
+            self._update_color_btn()
+
+    def _update_color_btn(self) -> None:
+        self.color_btn.setStyleSheet(
+            f"background-color: {self._color.name(QtGui.QColor.NameFormat.HexArgb)}"
+        )
+
     # --- Qt overrides ------------------------------------------------
     def accept(self) -> None:  # type: ignore[override]
-        self.settings.project_path = self.path_edit.text()
+        self.settings.original_path = self.original_edit.text()
+        self.settings.translation_path = self.translation_edit.text()
         self.settings.api_key = self.api_key_edit.text()
         self.settings.model = self.model_combo.currentText()
         self.settings.machine_check = self.machine_check_box.isChecked()
+        self.settings.auto_next = self.auto_next_box.isChecked()
+        self.settings.highlight_color = self._color.name(
+            QtGui.QColor.NameFormat.HexArgb
+        )
         self.settings.save()
         super().accept()
+


### PR DESCRIPTION
## Summary
- store settings via QSettings and support original/translation folders
- let users choose model, folders, auto-next chapter, and highlight color
- use configurable paths and auto advance when saving translations

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689c775f00788332afc1727fee061285