### PR TITLE
Add auto-prompt flag for glossaries

### DIFF
--- a/app/services/glossary.py
+++ b/app/services/glossary.py
@@ -19,6 +19,7 @@ class Glossary:
 
     name: str
     entries: Dict[str, str] = field(default_factory=dict)
+    auto_to_prompt: bool = False
     file: Path | None = None
 
     # ------------------------------------------------------------------
@@ -46,7 +47,11 @@ class Glossary:
         file_path = Path(path) if path else self.file
         if file_path is None:
             raise ValueError("Path must be provided for unsaved glossaries")
-        data = {"name": self.name, "entries": self.entries}
+        data = {
+            "name": self.name,
+            "entries": self.entries,
+            "auto_to_prompt": self.auto_to_prompt,
+        }
         file_path.write_text(
             json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
         )
@@ -58,7 +63,11 @@ class Glossary:
 
         file_path = Path(path)
         data = json.loads(file_path.read_text(encoding="utf-8"))
-        obj = cls(name=data.get("name", file_path.stem), entries=data.get("entries", {}))
+        obj = cls(
+            name=data.get("name", file_path.stem),
+            entries=data.get("entries", {}),
+            auto_to_prompt=data.get("auto_to_prompt", False),
+        )
         obj.file = file_path
         return obj
 

--- a/app/services/prompt.py
+++ b/app/services/prompt.py
@@ -5,16 +5,21 @@ from __future__ import annotations
 from .glossary import Glossary
 
 
-def build_prompt(text: str, glossary: Glossary | None = None, instruction: str | None = None) -> str:
-    """Create a prompt string using *text* and optional *glossary*.
+def build_prompt(
+    text: str,
+    glossaries: list[Glossary] | None = None,
+    instruction: str | None = None,
+) -> str:
+    """Create a prompt string using *text* and optional *glossaries*.
 
     Parameters
     ----------
     text:
         Main text to include in the prompt.
-    glossary:
-        Optional :class:`~app.services.glossary.Glossary` whose entries will
-        be appended to the prompt.
+    glossaries:
+        Optional list of :class:`~app.services.glossary.Glossary` instances.
+        Only glossaries with ``auto_to_prompt=True`` and at least one entry
+        are appended to the prompt.
     instruction:
         Additional instruction placed at the beginning of the prompt.
     """
@@ -23,7 +28,13 @@ def build_prompt(text: str, glossary: Glossary | None = None, instruction: str |
     if instruction:
         parts.append(instruction.strip())
     parts.append(text.strip())
-    if glossary and glossary.entries:
-        glossary_lines = "\n".join(f"{src} -> {dst}" for src, dst in glossary.entries.items())
-        parts.append("Glossary:\n" + glossary_lines)
+    if glossaries:
+        glossary_lines = [
+            f"{src} -> {dst}"
+            for g in glossaries
+            if g.auto_to_prompt
+            for src, dst in g.entries.items()
+        ]
+        if glossary_lines:
+            parts.append("Glossary:\n" + "\n".join(glossary_lines))
     return "\n\n".join(part for part in parts if part)

--- a/app/ui_main.py
+++ b/app/ui_main.py
@@ -151,6 +151,7 @@ class Ui_MainWindow(object):
         self.glossary_top.addWidget(self.add_glossary_btn)
         self.glossary_top.addWidget(self.rename_glossary_btn)
         self.glossary_top.addWidget(self.delete_glossary_btn)
+        self.auto_prompt_checkbox = QtWidgets.QCheckBox(parent=self.glossary_widget)
         self.glossary_table = QtWidgets.QTableWidget(parent=self.glossary_widget)
         self.glossary_table.setColumnCount(2)
         self.glossary_table.setHorizontalHeaderLabels(["Source", "Target"])
@@ -162,6 +163,7 @@ class Ui_MainWindow(object):
         self.pair_btn_layout.addWidget(self.add_pair_btn)
         self.pair_btn_layout.addWidget(self.remove_pair_btn)
         self.glossary_layout.addLayout(self.glossary_top)
+        self.glossary_layout.addWidget(self.auto_prompt_checkbox)
         self.glossary_layout.addWidget(self.glossary_table)
         self.glossary_layout.addLayout(self.pair_btn_layout)
         self.right_splitter.addWidget(self.glossary_widget)
@@ -173,6 +175,7 @@ class Ui_MainWindow(object):
         self.add_pair_btn.clicked.connect(self._add_pair)
         self.remove_pair_btn.clicked.connect(self._remove_pair)
         self.glossary_table.itemChanged.connect(self._on_pair_edited)
+        self.auto_prompt_checkbox.toggled.connect(self._on_auto_prompt_toggled)
 
         # Status/timer area
         self.status_layout = QtWidgets.QHBoxLayout()
@@ -368,9 +371,15 @@ class Ui_MainWindow(object):
         else:
             self.current_glossary = None
             self.glossary_table.setRowCount(0)
+            self.auto_prompt_checkbox.blockSignals(True)
+            self.auto_prompt_checkbox.setChecked(False)
+            self.auto_prompt_checkbox.blockSignals(False)
 
     def _load_glossary(self, path: Path) -> None:
         self.current_glossary = Glossary.load(path)
+        self.auto_prompt_checkbox.blockSignals(True)
+        self.auto_prompt_checkbox.setChecked(self.current_glossary.auto_to_prompt)
+        self.auto_prompt_checkbox.blockSignals(False)
         self._populate_table()
 
     def _populate_table(self) -> None:
@@ -430,6 +439,9 @@ class Ui_MainWindow(object):
         else:
             self.current_glossary = None
             self.glossary_table.setRowCount(0)
+            self.auto_prompt_checkbox.blockSignals(True)
+            self.auto_prompt_checkbox.setChecked(False)
+            self.auto_prompt_checkbox.blockSignals(False)
 
     def _add_pair(self) -> None:
         row = self.glossary_table.rowCount()
@@ -459,6 +471,11 @@ class Ui_MainWindow(object):
                 self.current_glossary.add(src, dst)
                 self.current_glossary.save()
 
+    def _on_auto_prompt_toggled(self, checked: bool) -> None:
+        if self.current_glossary:
+            self.current_glossary.auto_to_prompt = checked
+            self.current_glossary.save()
+
     def glossary_entries(self) -> dict[str, str]:
         if self.current_glossary:
             return dict(self.current_glossary.entries)
@@ -481,6 +498,7 @@ class Ui_MainWindow(object):
         self.add_glossary_btn.setText(_translate("MainWindow", "+"))
         self.rename_glossary_btn.setText(_translate("MainWindow", "Переименовать"))
         self.delete_glossary_btn.setText(_translate("MainWindow", "-"))
+        self.auto_prompt_checkbox.setText(_translate("MainWindow", "Авто в промпт"))
         self.add_pair_btn.setText(_translate("MainWindow", "Добавить"))
         self.remove_pair_btn.setText(_translate("MainWindow", "Удалить"))
 


### PR DESCRIPTION
## Summary
- add `auto_to_prompt` flag to glossaries with persistence
- expose checkbox in UI to toggle automatic inclusion in prompts
- generate prompts using only glossaries marked for auto inclusion

## Testing
- `python -m py_compile app/services/glossary.py app/services/prompt.py app/ui_main.py`


------
https://chatgpt.com/codex/tasks/task_e_689c7a11e750833293b1375386597acb