### PR TITLE
Use model-based synonyms with context and caching

### DIFF
--- a/app/ui_main.py
+++ b/app/ui_main.py
@@ -299,7 +299,12 @@ class Ui_MainWindow(object):
         word = cursor.selectedText().strip()
         if not word:
             return
-        synonyms = fetch_synonyms(word)
+        text = self.translation_edit.toPlainText()
+        start = cursor.selectionStart()
+        end = cursor.selectionEnd()
+        left_ctx = text[max(0, start - 40) : start]
+        right_ctx = text[end : end + 40]
+        synonyms = fetch_synonyms(word, left_ctx, right_ctx)
         if not synonyms:
             return
         menu = QtWidgets.QMenu(self.translation_edit)


### PR DESCRIPTION
## Summary
- Rewrite synonyms service to query the selected LLM with contextual system prompt and cache results by word and context
- Pass left and right context from translation editor to the synonyms service when showing the synonym menu

## Testing
- `python -m py_compile app/services/synonyms.py app/ui_main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c7c066a6083328b345179830ec1a7