### PR TITLE
Add selectable txt format for translations

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -17,6 +17,7 @@ from services.files import (
     load_docx,
     load_stats,
     save_docx,
+    save_txt,
 )
 from services.cloud import list_documents, load_document
 from services.reports import save_csv, save_html
@@ -254,24 +255,29 @@ class MainController:
         if not text:
             return
         src = self.chapters[idx]
+        ext = ".txt" if self.settings.format == "txt" else ".docx"
+        save_func = save_txt if self.settings.format == "txt" else save_docx
+
         if isinstance(src, tuple):
             _, name = src
             if self.settings.translation_path:
                 out_dir = Path(self.settings.translation_path)
                 out_dir.mkdir(parents=True, exist_ok=True)
-                out_path = out_dir / f"{name}.docx"
+                base = out_dir / name
             else:
-                out_path = Path(f"{name}_translated.docx")
-            save_docx(text, out_path)
+                base = Path(f"{name}_translated")
+            out_path = base.with_suffix(ext)
+            save_func(text, out_path)
             stat = {"chapter": name, "characters": len(text), "time": self.ui.elapsed}
         else:
             if self.settings.translation_path:
                 out_dir = Path(self.settings.translation_path)
                 out_dir.mkdir(parents=True, exist_ok=True)
-                out_path = out_dir / src.name
+                base = out_dir / src.stem
             else:
-                out_path = src.with_name(src.stem + "_translated.docx")
-            save_docx(text, out_path)
+                base = src.with_name(src.stem + "_translated")
+            out_path = base.with_suffix(ext)
+            save_func(text, out_path)
             stat = {"chapter": src.stem, "characters": len(text), "time": self.ui.elapsed}
         self.stats = append_stat(stat, self.stats_path)
         self.ui.reset_timer()

--- a/app/services/files.py
+++ b/app/services/files.py
@@ -85,6 +85,31 @@ def save_docx(text: str, path: Path | str) -> None:
         zf.writestr("word/document.xml", document_xml)
 
 
+def load_txt(path: Path | str) -> str:
+    """Read and return plain UTF-8 text from *path*.
+
+    The function simply opens the file using UTF-8 encoding and returns its
+    contents. It mirrors :func:`load_docx` for text files and is intentionally
+    small because the project only requires basic text handling.
+    """
+
+    file_path = Path(path)
+    with file_path.open("r", encoding="utf-8") as fh:
+        return fh.read()
+
+
+def save_txt(text: str, path: Path | str) -> None:
+    """Write *text* to *path* encoded as UTF-8.
+
+    This complements :func:`save_docx` and provides a lightweight way to store
+    translations in plain text format without any additional dependencies.
+    """
+
+    file_path = Path(path)
+    with file_path.open("w", encoding="utf-8") as fh:
+        fh.write(text)
+
+
 def _build_document_xml(text: str) -> str:
     ns = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
     ET.register_namespace("w", ns)

--- a/app/settings.py
+++ b/app/settings.py
@@ -26,6 +26,8 @@ class AppSettings:
         Whether machine translation verification is enabled.
     auto_next:
         Move to the next chapter automatically after saving.
+    format:
+        Output format for saved translations ("docx" or "txt").
     gdoc_token:
         OAuth token for accessing Google Docs.
     gdoc_folder_id:
@@ -40,6 +42,7 @@ class AppSettings:
     model: str = ""
     machine_check: bool = False
     auto_next: bool = False
+    format: str = "docx"
     gdoc_token: str = ""
     gdoc_folder_id: str = ""
     highlight_color: str = "#80ffff00"  # semi-transparent yellow
@@ -57,6 +60,7 @@ class AppSettings:
         qs.setValue("model", self.model)
         qs.setValue("machine_check", self.machine_check)
         qs.setValue("auto_next", self.auto_next)
+        qs.setValue("format", self.format)
         qs.setValue("gdoc_token", self.gdoc_token)
         qs.setValue("gdoc_folder_id", self.gdoc_folder_id)
         qs.setValue("highlight_color", self.highlight_color)
@@ -76,6 +80,7 @@ class AppSettings:
             model=qs.value("model", "", str),
             machine_check=qs.value("machine_check", False, bool),
             auto_next=qs.value("auto_next", False, bool),
+            format=qs.value("format", "docx", str),
             gdoc_token=qs.value("gdoc_token", "", str),
             gdoc_folder_id=qs.value("gdoc_folder_id", "", str),
             highlight_color=qs.value("highlight_color", "#80ffff00", str),
@@ -128,6 +133,12 @@ class SettingsDialog(QtWidgets.QDialog):
         self.auto_next_box = QtWidgets.QCheckBox()
         self.auto_next_box.setChecked(settings.auto_next)
 
+        self.format_combo = QtWidgets.QComboBox()
+        self.format_combo.addItems(["docx", "txt"])
+        index = self.format_combo.findText(settings.format)
+        if index != -1:
+            self.format_combo.setCurrentIndex(index)
+
         self.color_btn = QtWidgets.QPushButton()
         self._update_color_btn()
         self.color_btn.clicked.connect(self._choose_color)
@@ -138,6 +149,7 @@ class SettingsDialog(QtWidgets.QDialog):
         layout.addRow("Токен Google Docs", self.gdoc_token_edit)
         layout.addRow("ID папки Google Docs", self.gdoc_folder_edit)
         layout.addRow("Модель", self.model_combo)
+        layout.addRow("Формат", self.format_combo)
         layout.addRow("Машинная проверка", self.machine_check_box)
         layout.addRow("Следующая глава", self.auto_next_box)
         layout.addRow("Цвет подсветки", self.color_btn)
@@ -179,6 +191,7 @@ class SettingsDialog(QtWidgets.QDialog):
         self.settings.model = self.model_combo.currentText()
         self.settings.machine_check = self.machine_check_box.isChecked()
         self.settings.auto_next = self.auto_next_box.isChecked()
+        self.settings.format = self.format_combo.currentText()
         self.settings.highlight_color = self._color.name(
             QtGui.QColor.NameFormat.HexArgb
         )


### PR DESCRIPTION
## Summary
- add plain text load/save helpers
- allow choosing output format in settings dialog
- save translations as docx or txt depending on chosen format

## Testing
- `pytest -q`
- `python -m py_compile app/services/files.py app/settings.py app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_689ca961acc0833288c2ca2452753cb4