### PR TITLE
Add per-model API key settings and dynamic model selection

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -68,7 +68,13 @@ class MainController:
         self.ui.chapter_combo.currentIndexChanged.connect(self.load_chapter)
 
         # model selection and saving
-        self.ui.model_combo.addItems(sorted(_MODELS.keys()))
+        models = [
+            name
+            for name in sorted(_MODELS.keys())
+            if getattr(self.settings, f"{name}_key", "")
+        ]
+        self.ui.model_combo.clear()
+        self.ui.model_combo.addItems(models)
         if self.settings.model:
             idx = self.ui.model_combo.findText(self.settings.model)
             if idx != -1:
@@ -161,7 +167,7 @@ class MainController:
         prompt = self.ui.mini_prompt_edit.toPlainText().strip()
         glossary = self._parse_glossary()
         try:
-            model = get_translator(self.settings.model or "gemini")
+            model = get_translator(self.settings.model or "gemini", self.settings)
         except Exception as exc:  # pragma: no cover - settings misuse
             QtWidgets.QMessageBox.critical(self.window, "Ошибка", str(exc))
             return
@@ -212,7 +218,7 @@ class MainController:
         prompt = self.ui.mini_prompt_edit.toPlainText().strip()
         glossary = self._parse_glossary()
         try:
-            model = get_translator(self.settings.model or "gemini")
+            model = get_translator(self.settings.model or "gemini", self.settings)
         except Exception as exc:  # pragma: no cover - settings misuse
             QtWidgets.QMessageBox.critical(self.window, "Ошибка", str(exc))
             self._process_queue()

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, Type
 
+from settings import AppSettings
+
 from .deepl import DeepLTranslator
 from .gemini import GeminiTranslator
 from .grok import GrokTranslator
@@ -21,8 +23,8 @@ _MODELS: Dict[str, TranslatorType] = {
 }
 
 
-def get_translator(name: str):
-    """Return a translator instance for *name*.
+def get_translator(name: str, settings: AppSettings | None = None):
+    """Return a translator instance for *name* using the appropriate key.
 
     The lookup is case-insensitive. ``ValueError`` is raised for unknown
     names.
@@ -31,7 +33,10 @@ def get_translator(name: str):
     cls = _MODELS.get(name.lower())
     if not cls:
         raise ValueError(f"Unknown model: {name}")
-    return cls()
+
+    settings = settings or AppSettings.load()
+    key = getattr(settings, f"{name.lower()}_key", "")
+    return cls(api_key=key)
 
 
 def fetch_synonyms_llm(word: str, model_name: str) -> list[str]:

--- a/app/models/deepl.py
+++ b/app/models/deepl.py
@@ -2,12 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Dict, Optional
+from typing import Dict
 import json
 from urllib import error, parse, request
-
-from settings import AppSettings
-
 
 class DeepLTranslator:
     """Simple wrapper around the DeepL HTTP API.
@@ -15,19 +12,17 @@ class DeepLTranslator:
     Parameters
     ----------
     api_key:
-        Optional API key. If not provided, the key is loaded from
-        :class:`settings.AppSettings`.
+        API key for the DeepL service.
     """
 
     #: Endpoint for the free DeepL API tier. The user may need to change this
     #: to ``api.deepl.com`` for a paid subscription.
     BASE_URL = "https://api-free.deepl.com/v2/translate"
 
-    def __init__(self, api_key: Optional[str] = None) -> None:
-        settings = AppSettings.load()
-        self.api_key = api_key or settings.api_key
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
         if not self.api_key:
-            raise ValueError("DeepL API key not found in settings")
+            raise ValueError("DeepL API key not provided")
 
     # ------------------------------------------------------------------
     def translate(

--- a/app/models/gemini.py
+++ b/app/models/gemini.py
@@ -2,12 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Dict, Optional
+from typing import Dict
 import json
 from urllib import error, request
-
-from settings import AppSettings
-
 
 class GeminiTranslator:
     """Translate text using Google's Gemini models."""
@@ -17,11 +14,10 @@ class GeminiTranslator:
         "gemini-pro:generateContent"
     )
 
-    def __init__(self, api_key: Optional[str] = None) -> None:
-        settings = AppSettings.load()
-        self.api_key = api_key or settings.api_key
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
         if not self.api_key:
-            raise ValueError("Gemini API key not found in settings")
+            raise ValueError("Gemini API key not provided")
 
     # ------------------------------------------------------------------
     def translate(

--- a/app/models/grok.py
+++ b/app/models/grok.py
@@ -6,8 +6,6 @@ from typing import Dict, Optional
 import json
 from urllib import error, request
 
-from settings import AppSettings
-
 
 class GrokTranslator:
     """Translate text using xAI's Grok model."""
@@ -15,11 +13,10 @@ class GrokTranslator:
     BASE_URL = "https://api.x.ai/v1/chat/completions"
     DEFAULT_MODEL = "grok-beta"
 
-    def __init__(self, api_key: Optional[str] = None, model: str | None = None) -> None:
-        settings = AppSettings.load()
-        self.api_key = api_key or settings.api_key
+    def __init__(self, api_key: str, model: str | None = None) -> None:
+        self.api_key = api_key
         if not self.api_key:
-            raise ValueError("Grok API key not found in settings")
+            raise ValueError("Grok API key not provided")
         self.model = model or self.DEFAULT_MODEL
 
     # ------------------------------------------------------------------

--- a/app/models/qwen.py
+++ b/app/models/qwen.py
@@ -6,8 +6,6 @@ from typing import Dict, Optional
 import json
 from urllib import error, request
 
-from settings import AppSettings
-
 
 class QwenTranslator:
     """Translate text using the Qwen model."""
@@ -15,11 +13,10 @@ class QwenTranslator:
     BASE_URL = "https://api.qwen.ai/v1/chat/completions"
     DEFAULT_MODEL = "qwen-turbo"
 
-    def __init__(self, api_key: Optional[str] = None, model: str | None = None) -> None:
-        settings = AppSettings.load()
-        self.api_key = api_key or settings.api_key
+    def __init__(self, api_key: str, model: str | None = None) -> None:
+        self.api_key = api_key
         if not self.api_key:
-            raise ValueError("Qwen API key not found in settings")
+            raise ValueError("Qwen API key not provided")
         self.model = model or self.DEFAULT_MODEL
 
     # ------------------------------------------------------------------

--- a/app/settings.py
+++ b/app/settings.py
@@ -20,8 +20,14 @@ class AppSettings:
         Folder containing original chapters.
     translation_path:
         Folder where translated chapters and metadata are stored.
-    api_key:
-        Key for accessing external translation services.
+    gemini_key:
+        API key for the Gemini model.
+    deepl_key:
+        API key for the DeepL service.
+    grok_key:
+        API key for xAI's Grok model.
+    qwen_key:
+        API key for the Qwen model.
     model:
         Identifier of the LLM or translation model in use.
     synonym_provider:
@@ -45,7 +51,10 @@ class AppSettings:
 
     original_path: str = ""
     translation_path: str = ""
-    api_key: str = ""
+    gemini_key: str = ""
+    deepl_key: str = ""
+    grok_key: str = ""
+    qwen_key: str = ""
     model: str = ""
     synonym_provider: str = "datamuse"
     machine_check: bool = False
@@ -67,7 +76,10 @@ class AppSettings:
         qs = QtCore.QSettings(str(file_path), QtCore.QSettings.Format.IniFormat)
         qs.setValue("original_path", self.original_path)
         qs.setValue("translation_path", self.translation_path)
-        qs.setValue("api_key", self.api_key)
+        qs.setValue("gemini_key", self.gemini_key)
+        qs.setValue("deepl_key", self.deepl_key)
+        qs.setValue("grok_key", self.grok_key)
+        qs.setValue("qwen_key", self.qwen_key)
         qs.setValue("model", self.model)
         qs.setValue("synonym_provider", self.synonym_provider)
         qs.setValue("machine_check", self.machine_check)
@@ -91,7 +103,10 @@ class AppSettings:
         obj = cls(
             original_path=qs.value("original_path", "", str),
             translation_path=qs.value("translation_path", "", str),
-            api_key=qs.value("api_key", "", str),
+            gemini_key=qs.value("gemini_key", "", str),
+            deepl_key=qs.value("deepl_key", "", str),
+            grok_key=qs.value("grok_key", "", str),
+            qwen_key=qs.value("qwen_key", "", str),
             model=qs.value("model", "", str),
             synonym_provider=qs.value("synonym_provider", "datamuse", str),
             machine_check=qs.value("machine_check", False, bool),
@@ -136,7 +151,10 @@ class SettingsDialog(QtWidgets.QDialog):
         trans_layout.addWidget(self.translation_edit)
         trans_layout.addWidget(trans_btn)
 
-        self.api_key_edit = QtWidgets.QLineEdit(settings.api_key)
+        self.gemini_key_edit = QtWidgets.QLineEdit(settings.gemini_key)
+        self.deepl_key_edit = QtWidgets.QLineEdit(settings.deepl_key)
+        self.grok_key_edit = QtWidgets.QLineEdit(settings.grok_key)
+        self.qwen_key_edit = QtWidgets.QLineEdit(settings.qwen_key)
         self.gdoc_token_edit = QtWidgets.QLineEdit(settings.gdoc_token)
         self.gdoc_folder_edit = QtWidgets.QLineEdit(settings.gdoc_folder_id)
 
@@ -188,7 +206,10 @@ class SettingsDialog(QtWidgets.QDialog):
 
         layout.addRow("Папка оригинала", orig_layout)
         layout.addRow("Папка перевода", trans_layout)
-        layout.addRow("API ключ", self.api_key_edit)
+        layout.addRow("Ключ Gemini", self.gemini_key_edit)
+        layout.addRow("Ключ DeepL", self.deepl_key_edit)
+        layout.addRow("Ключ Grok", self.grok_key_edit)
+        layout.addRow("Ключ Qwen", self.qwen_key_edit)
         layout.addRow("Токен Google Docs", self.gdoc_token_edit)
         layout.addRow("ID папки Google Docs", self.gdoc_folder_edit)
         layout.addRow("Модель", self.model_combo)
@@ -243,7 +264,10 @@ class SettingsDialog(QtWidgets.QDialog):
     def accept(self) -> None:  # type: ignore[override]
         self.settings.original_path = self.original_edit.text()
         self.settings.translation_path = self.translation_edit.text()
-        self.settings.api_key = self.api_key_edit.text()
+        self.settings.gemini_key = self.gemini_key_edit.text()
+        self.settings.deepl_key = self.deepl_key_edit.text()
+        self.settings.grok_key = self.grok_key_edit.text()
+        self.settings.qwen_key = self.qwen_key_edit.text()
         self.settings.gdoc_token = self.gdoc_token_edit.text()
         self.settings.gdoc_folder_id = self.gdoc_folder_edit.text()
         self.settings.model = self.model_combo.currentText()

--- a/app/ui_main.py
+++ b/app/ui_main.py
@@ -23,7 +23,7 @@ from services.glossary import (
 )
 from settings import AppSettings, SettingsDialog
 from services.synonyms import fetch_synonyms as fetch_synonyms_datamuse
-from models import fetch_synonyms_llm
+from models import fetch_synonyms_llm, _MODELS
 from .diff_utils import DiffHighlighter
 
 def resource_path(name: str) -> str:
@@ -66,6 +66,16 @@ class Ui_MainWindow(object):
         self.chapter_combo = QtWidgets.QComboBox(parent=self.centralwidget)
         self.next_btn = QtWidgets.QPushButton(parent=self.centralwidget)
         self.model_combo = QtWidgets.QComboBox(parent=self.centralwidget)
+        models = [
+            name
+            for name in sorted(_MODELS.keys())
+            if getattr(self.settings, f"{name}_key", "")
+        ]
+        self.model_combo.addItems(models)
+        if self.settings.model:
+            idx = self.model_combo.findText(self.settings.model)
+            if idx != -1:
+                self.model_combo.setCurrentIndex(idx)
         self.save_btn = QtWidgets.QPushButton(parent=self.centralwidget)
         self.save_btn.setIcon(QIcon(resource_path("сохранить.png")))
         self.nav_layout.addWidget(self.prev_btn)


### PR DESCRIPTION
## Summary
- Store separate API keys for Gemini, DeepL, Grok and Qwen in `AppSettings`
- Provide dedicated key fields in the settings dialog
- Populate model selector with only models that have a configured key and pass keys to translators

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689cbd8e74208332a89ecb5911dd0dd3