### PR TITLE
Add customizable theme colors

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -54,6 +54,12 @@ class AppSettings:
         Identifier of the Google Drive folder containing chapters.
     highlight_color:
         Background colour for diff highlighting in ARGB hex format.
+    app_background:
+        Background colour of the main interface.
+    accent_color:
+        Accent colour for focused elements.
+    text_color:
+        Default text colour for widgets.
     chapter_template:
         Template for naming saved chapters. Use "{n}" as a placeholder for the
         chapter number.
@@ -77,6 +83,9 @@ class AppSettings:
     gdoc_token: str = ""
     gdoc_folder_id: str = ""
     highlight_color: str = "#80ffff00"  # semi-transparent yellow
+    app_background: str = styles.APP_BACKGROUND
+    accent_color: str = styles.ACCENT_COLOR
+    text_color: str = styles.TEXT_COLOR
     neon_color: str = styles.ACCENT_COLOR
     neon_intensity: int = 20
     chapter_template: str = "глава {n}"
@@ -106,6 +115,9 @@ class AppSettings:
         qs.setValue("gdoc_token", self.gdoc_token)
         qs.setValue("gdoc_folder_id", self.gdoc_folder_id)
         qs.setValue("highlight_color", self.highlight_color)
+        qs.setValue("app_background", self.app_background)
+        qs.setValue("accent_color", self.accent_color)
+        qs.setValue("text_color", self.text_color)
         qs.setValue("neon_color", self.neon_color)
         qs.setValue("neon_intensity", self.neon_intensity)
         qs.setValue("chapter_template", self.chapter_template)
@@ -137,6 +149,9 @@ class AppSettings:
             gdoc_token=qs.value("gdoc_token", "", str),
             gdoc_folder_id=qs.value("gdoc_folder_id", "", str),
             highlight_color=qs.value("highlight_color", "#80ffff00", str),
+            app_background=qs.value("app_background", styles.APP_BACKGROUND, str),
+            accent_color=qs.value("accent_color", styles.ACCENT_COLOR, str),
+            text_color=qs.value("text_color", styles.TEXT_COLOR, str),
             neon_color=qs.value("neon_color", styles.ACCENT_COLOR, str),
             neon_intensity=qs.value("neon_intensity", 20, int),
             chapter_template=qs.value("chapter_template", "глава {n}", str),
@@ -265,6 +280,46 @@ class SettingsDialog(QtWidgets.QDialog):
 
         self.chapter_template_edit = QtWidgets.QLineEdit(settings.chapter_template)
 
+        self.app_bg_edit = QtWidgets.QLineEdit(settings.app_background)
+        self.app_bg_btn = QtWidgets.QPushButton()
+        self.app_bg_btn.setStyleSheet(
+            f"background-color: {settings.app_background}"
+        )
+        self.app_bg_btn.clicked.connect(
+            lambda: self._choose_named_color(self.app_bg_edit, self.app_bg_btn)
+        )
+        self.app_bg_edit.textChanged.connect(
+            lambda text: self.app_bg_btn.setStyleSheet(f"background-color: {text}")
+        )
+
+        self.accent_color_edit = QtWidgets.QLineEdit(settings.accent_color)
+        self.accent_color_btn = QtWidgets.QPushButton()
+        self.accent_color_btn.setStyleSheet(
+            f"background-color: {settings.accent_color}"
+        )
+        self.accent_color_btn.clicked.connect(
+            lambda: self._choose_named_color(
+                self.accent_color_edit, self.accent_color_btn
+            )
+        )
+        self.accent_color_edit.textChanged.connect(
+            lambda text: self.accent_color_btn.setStyleSheet(
+                f"background-color: {text}"
+            )
+        )
+
+        self.text_color_edit = QtWidgets.QLineEdit(settings.text_color)
+        self.text_color_btn = QtWidgets.QPushButton()
+        self.text_color_btn.setStyleSheet(
+            f"background-color: {settings.text_color}"
+        )
+        self.text_color_btn.clicked.connect(
+            lambda: self._choose_named_color(self.text_color_edit, self.text_color_btn)
+        )
+        self.text_color_edit.textChanged.connect(
+            lambda text: self.text_color_btn.setStyleSheet(f"background-color: {text}")
+        )
+
         self.color_btn = QtWidgets.QPushButton()
         self._update_color_btn()
         self.color_btn.clicked.connect(self._choose_color)
@@ -293,6 +348,18 @@ class SettingsDialog(QtWidgets.QDialog):
         layout.addRow("Формат", self.format_combo)
         layout.addRow("Машинная проверка", self.machine_check_box)
         layout.addRow("Следующая глава", self.auto_next_box)
+        bg_layout = QtWidgets.QHBoxLayout()
+        bg_layout.addWidget(self.app_bg_edit)
+        bg_layout.addWidget(self.app_bg_btn)
+        layout.addRow("Фон приложения", bg_layout)
+        accent_layout = QtWidgets.QHBoxLayout()
+        accent_layout.addWidget(self.accent_color_edit)
+        accent_layout.addWidget(self.accent_color_btn)
+        layout.addRow("Акцентный цвет", accent_layout)
+        text_layout = QtWidgets.QHBoxLayout()
+        text_layout.addWidget(self.text_color_edit)
+        text_layout.addWidget(self.text_color_btn)
+        layout.addRow("Цвет текста", text_layout)
         layout.addRow("Цвет подсветки", self.color_btn)
         layout.addRow("Цвет свечения", self.neon_color_slider)
         layout.addRow("Интенсивность свечения", self.neon_intensity_slider)
@@ -421,6 +488,14 @@ class SettingsDialog(QtWidgets.QDialog):
             self._color = color
             self._update_color_btn()
 
+    def _choose_named_color(
+        self, edit: QtWidgets.QLineEdit, btn: QtWidgets.QPushButton
+    ) -> None:
+        color = QtWidgets.QColorDialog.getColor(QtGui.QColor(edit.text()), self)
+        if color.isValid():
+            edit.setText(color.name())
+            btn.setStyleSheet(f"background-color: {color.name()}")
+
     def _update_neon_preview(self) -> None:
         color = QtGui.QColor.fromHsv(
             self.neon_color_slider.value(),
@@ -467,6 +542,9 @@ class SettingsDialog(QtWidgets.QDialog):
         self.settings.machine_check = self.machine_check_box.isChecked()
         self.settings.auto_next = self.auto_next_box.isChecked()
         self.settings.format = self.format_combo.currentText()
+        self.settings.app_background = self.app_bg_edit.text()
+        self.settings.accent_color = self.accent_color_edit.text()
+        self.settings.text_color = self.text_color_edit.text()
         self.settings.highlight_color = self._color.name(
             QtGui.QColor.NameFormat.HexArgb
         )
@@ -478,6 +556,7 @@ class SettingsDialog(QtWidgets.QDialog):
         self.settings.neon_color = neon.name()
         self.settings.neon_intensity = self.neon_intensity_slider.value()
         self.settings.chapter_template = self.chapter_template_edit.text()
+        styles.init(self.settings)
         self.settings.save()
         super().accept()
 

--- a/app/styles.py
+++ b/app/styles.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from PyQt6 import QtGui
+from typing import Any
 
 # Color palette (dark theme)
 APP_BACKGROUND = "#212121"
@@ -15,15 +16,18 @@ ACCENT_COLOR = "#00E5FF"
 INTER_FONT = "Inter"
 HEADER_FONT = "Cattedrale"
 
-# QSS rule that highlights widgets when hovered or focused
-FOCUS_HOVER_RULE = f"""
+
+def focus_hover_rule(color: str) -> str:
+    """Return a QSS snippet highlighting widgets on focus/hover."""
+
+    return f"""
 QTextEdit:focus,
 QTextEdit:hover,
 QLineEdit:focus,
 QLineEdit:hover,
 QTableWidget#glossary:focus,
 QTableWidget#glossary:hover {{
-    border: 1px solid {ACCENT_COLOR};
+    border: 1px solid {color};
 }}
 """.strip()
 
@@ -52,14 +56,14 @@ QTableWidget#glossary:hover {{
 """.strip()
 
 
-def init() -> None:
-    """Load bundled fonts and expose their family names.
+def init(settings: Any | None = None) -> None:
+    """Load bundled fonts and apply user-selected colours."""
 
-    The application ships with custom fonts (Inter and Cattedrale).  They are
-    added to the Qt font database when the UI is initialised so that widgets can
-    reference them by family name.  If loading fails, the default family names
-    declared above are kept.
-    """
+    if settings is not None:
+        global APP_BACKGROUND, ACCENT_COLOR, TEXT_COLOR
+        APP_BACKGROUND = getattr(settings, "app_background", APP_BACKGROUND)
+        ACCENT_COLOR = getattr(settings, "accent_color", ACCENT_COLOR)
+        TEXT_COLOR = getattr(settings, "text_color", TEXT_COLOR)
 
     font_db = QtGui.QFontDatabase()
 

--- a/app/ui_main.py
+++ b/app/ui_main.py
@@ -40,9 +40,9 @@ class Ui_MainWindow(object):
         print(f"Application version: {__version__}")
         MainWindow.setObjectName("MainWindow")
         MainWindow.resize(800, 600)
-        styles.init()
 
         self.settings = settings or AppSettings.load()
+        styles.init(self.settings)
         self.current_glossary: Glossary | None = None
         self._current_word: str = ""
         self._current_context: str = ""
@@ -253,16 +253,17 @@ class Ui_MainWindow(object):
         glow_rule = styles.neon_glow_rule(
             self.settings.neon_color, self.settings.neon_intensity
         )
+        focus_rule = styles.focus_hover_rule(self.settings.accent_color)
         style_sheet = f"""
         QWidget {{
-            background-color: {styles.APP_BACKGROUND};
-            color: {styles.TEXT_COLOR};
+            background-color: {self.settings.app_background};
+            color: {self.settings.text_color};
             font-family: {styles.INTER_FONT};
         }}
         QTextEdit,
         QLineEdit {{
             background-color: {styles.FIELD_BACKGROUND};
-            color: {styles.TEXT_COLOR};
+            color: {self.settings.text_color};
             border: 1px solid transparent;
         }}
         QTableWidget#glossary {{
@@ -273,6 +274,7 @@ class Ui_MainWindow(object):
             color: rgba(255, 255, 255, 128);
             font-size: 10px;
         }}
+        {focus_rule}
         {glow_rule}
         """
         self.centralwidget.setStyleSheet(style_sheet)


### PR DESCRIPTION
## Summary
- allow configuring app background, accent, and text colors through SettingsDialog
- persist new color choices in AppSettings and apply them during style initialization
- apply selected colors across the interface via updated `_apply_style`

## Testing
- `python -m py_compile app/*.py app/models/*.py app/services/*.py`
- `python - <<'PY'
import app.settings
import app.ui_main
PY` *(fails: ModuleNotFoundError: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_689cc46256e8833296219d9a4b5ea5ae