### PR TITLE
Use relative imports within app package

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9,8 +9,8 @@ from typing import Dict, Tuple
 
 from PyQt6 import QtGui, QtWidgets
 
-from models import get_translator, _MODELS
-from services.files import (
+from .models import get_translator, _MODELS
+from .services.files import (
     append_stat,
     enqueue_chapters,
     iter_docx_files,
@@ -19,12 +19,12 @@ from services.files import (
     save_docx,
     save_txt,
 )
-from services.cloud import list_documents, load_document
-from services.reports import save_csv, save_html
-from services.versioning import check_for_updates, pull_updates
-from services.workers import DEFAULT_RATE_LIMITER, ModelWorker
-from ui_main import Ui_MainWindow
-from settings import AppSettings
+from .services.cloud import list_documents, load_document
+from .services.reports import save_csv, save_html
+from .services.versioning import check_for_updates, pull_updates
+from .services.workers import DEFAULT_RATE_LIMITER, ModelWorker
+from .ui_main import Ui_MainWindow
+from .settings import AppSettings
 
 
 class MainController:

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Type
 
-from settings import AppSettings
+from ..settings import AppSettings
 
 from .deepl import DeepLTranslator
 from .gemini import GeminiTranslator

--- a/app/settings.py
+++ b/app/settings.py
@@ -7,9 +7,9 @@ from pathlib import Path
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
-import styles
-from services.files import load_stats, save_stats
-from services.glossary import Glossary, list_glossaries
+from . import styles
+from .services.files import load_stats, save_stats
+from .services.glossary import Glossary, list_glossaries
 
 
 @dataclass
@@ -450,19 +450,19 @@ class SettingsDialog(QtWidgets.QDialog):
             return
         try:
             if name == "gemini":
-                from models.gemini import GeminiTranslator
+                from .models.gemini import GeminiTranslator
 
                 GeminiTranslator(key).translate("ping")
             elif name == "deepl":
-                from models.deepl import DeepLTranslator
+                from .models.deepl import DeepLTranslator
 
                 DeepLTranslator(key).translate("ping")
             elif name == "grok":
-                from models.grok import GrokTranslator
+                from .models.grok import GrokTranslator
 
                 GrokTranslator(key).translate("ping")
             elif name == "qwen":
-                from models.qwen import QwenTranslator
+                from .models.qwen import QwenTranslator
 
                 QwenTranslator(key).translate("ping")
             success = True

--- a/app/ui_main.py
+++ b/app/ui_main.py
@@ -8,11 +8,11 @@ from pathlib import Path
 from PyQt6 import QtCore, QtGui, QtWidgets
 from PyQt6.QtGui import QIcon
 
-import styles
+from . import styles
 from . import __version__
-from services.versioning import VersionManager
-from services.morphology import MorphologyService, MorphologyHighlighter
-from services.glossary import (
+from .services.versioning import VersionManager
+from .services.morphology import MorphologyService, MorphologyHighlighter
+from .services.glossary import (
     Glossary,
     create_glossary,
     delete_glossary,
@@ -21,9 +21,9 @@ from services.glossary import (
     import_csv,
     export_csv,
 )
-from settings import AppSettings, SettingsDialog
-from services.synonyms import fetch_synonyms as fetch_synonyms_datamuse
-from models import fetch_synonyms_llm, _MODELS
+from .settings import AppSettings, SettingsDialog
+from .services.synonyms import fetch_synonyms as fetch_synonyms_datamuse
+from .models import fetch_synonyms_llm, _MODELS
 from .diff_utils import DiffHighlighter
 
 def resource_path(name: str) -> str:


### PR DESCRIPTION
## Summary
- switch intra-package imports in app modules to explicit relative style
- adjust settings module to import translators from the package
- ensure UI and entry point reference services via relative paths

## Testing
- `pip install PyQt6`
- `apt-get update`
- `apt-get install -y libgl1`
- `apt-get install -y libegl1`
- `apt-get install -y libxkbcommon0`
- `QT_QPA_PLATFORM=offscreen python -m app.main` *(fails: `TypeError: QFontDatabase(a0: QFontDatabase): not enough arguments`)*

------
https://chatgpt.com/codex/tasks/task_e_689cd896a79c8332b5de81b1156d1c04