### PR TITLE
Fix PyQt6 font directory detection

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 from queue import Queue
 from typing import Tuple
+
+# Qt 6 no longer ships default fonts. Ensure the application has a font
+# directory available so that the GUI doesn't hang on startup when
+# QFontDatabase tries to locate fonts. We bundle fonts under ``app/fonts``
+# and point ``QT_QPA_FONTDIR`` there before importing any Qt modules.
+os.environ.setdefault("QT_QPA_FONTDIR", str(Path(__file__).resolve().parent / "fonts"))
 
 from PyQt6 import QtGui, QtWidgets
 


### PR DESCRIPTION
## Summary
- ensure PyQt6 can locate bundled fonts by setting `QT_QPA_FONTDIR`

## Testing
- `python -m py_compile app/main.py app/ui_main.py app/styles.py`


------
https://chatgpt.com/codex/tasks/task_e_689cff448e78833291182b19f9647697