### PR TITLE
Add border radius to text and glossary widgets

### DIFF
--- a/app/ui_main.py
+++ b/app/ui_main.py
@@ -302,10 +302,12 @@ class Ui_MainWindow(object):
             background-color: {styles.FIELD_BACKGROUND};
             color: {self.settings.text_color};
             border: 1px solid transparent;
+            border-radius: 6px;
         }}
         QTableWidget#glossary {{
             background-color: {styles.GLOSSARY_BACKGROUND};
             border: 1px solid transparent;
+            border-radius: 6px;
         }}
         QLabel#counter {{
             color: rgba(255, 255, 255, 128);


### PR DESCRIPTION
## Summary
- round QTextEdit and QLineEdit fields with 6px border radius
- apply same 6px radius to glossary table widget

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689da2439b508332bc2e2b0412be7d11