### PR TITLE
Add configurable font size

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -60,6 +60,8 @@ class AppSettings:
         Accent colour for focused elements.
     text_color:
         Default text colour for widgets.
+    font_size:
+        Base font size for text areas and tables.
     chapter_template:
         Template for naming saved chapters. Use "{n}" as a placeholder for the
         chapter number.
@@ -88,6 +90,7 @@ class AppSettings:
     text_color: str = styles.TEXT_COLOR
     neon_color: str = styles.ACCENT_COLOR
     neon_intensity: int = 20
+    font_size: int = 10
     chapter_template: str = "глава {n}"
     _file: Path = field(default=Path("settings.ini"), repr=False)
 
@@ -118,6 +121,7 @@ class AppSettings:
         qs.setValue("app_background", self.app_background)
         qs.setValue("accent_color", self.accent_color)
         qs.setValue("text_color", self.text_color)
+        qs.setValue("font_size", self.font_size)
         qs.setValue("neon_color", self.neon_color)
         qs.setValue("neon_intensity", self.neon_intensity)
         qs.setValue("chapter_template", self.chapter_template)
@@ -152,6 +156,7 @@ class AppSettings:
             app_background=qs.value("app_background", styles.APP_BACKGROUND, str),
             accent_color=qs.value("accent_color", styles.ACCENT_COLOR, str),
             text_color=qs.value("text_color", styles.TEXT_COLOR, str),
+            font_size=qs.value("font_size", 10, int),
             neon_color=qs.value("neon_color", styles.ACCENT_COLOR, str),
             neon_intensity=qs.value("neon_intensity", 20, int),
             chapter_template=qs.value("chapter_template", "глава {n}", str),
@@ -360,6 +365,11 @@ class SettingsDialog(QtWidgets.QDialog):
         text_layout.addWidget(self.text_color_edit)
         text_layout.addWidget(self.text_color_btn)
         layout.addRow("Цвет текста", text_layout)
+
+        self.font_size_spin = QtWidgets.QSpinBox()
+        self.font_size_spin.setRange(6, 48)
+        self.font_size_spin.setValue(settings.font_size)
+        layout.addRow("Размер шрифта", self.font_size_spin)
         layout.addRow("Цвет подсветки", self.color_btn)
         layout.addRow("Цвет свечения", self.neon_color_slider)
         layout.addRow("Интенсивность свечения", self.neon_intensity_slider)
@@ -555,6 +565,7 @@ class SettingsDialog(QtWidgets.QDialog):
         )
         self.settings.neon_color = neon.name()
         self.settings.neon_intensity = self.neon_intensity_slider.value()
+        self.settings.font_size = self.font_size_spin.value()
         self.settings.chapter_template = self.chapter_template_edit.text()
         styles.init(self.settings)
         self.settings.save()

--- a/app/ui_main.py
+++ b/app/ui_main.py
@@ -260,7 +260,7 @@ class Ui_MainWindow(object):
         self.main_layout.addLayout(self.status_layout)
 
         # Fonts
-        base_font = QtGui.QFont(styles.INTER_FONT, 10)
+        base_font = QtGui.QFont(styles.INTER_FONT, self.settings.font_size)
         self.original_edit.setFont(base_font)
         self.translation_edit.setFont(base_font)
         self.mini_prompt_edit.setFont(base_font)
@@ -322,6 +322,13 @@ class Ui_MainWindow(object):
         {glow_rule}
         """
         self.centralwidget.setStyleSheet(style_sheet)
+
+    def _apply_font_size(self) -> None:
+        base_font = QtGui.QFont(styles.INTER_FONT, self.settings.font_size)
+        self.original_edit.setFont(base_font)
+        self.translation_edit.setFont(base_font)
+        self.mini_prompt_edit.setFont(base_font)
+        self.glossary_table.setFont(base_font)
 
     # --- internal helpers -------------------------------------------------
     def _update_timer(self) -> None:
@@ -440,6 +447,7 @@ class Ui_MainWindow(object):
                 self._disable_machine_check()
             self.diff_highlighter.set_color(self.settings.highlight_color)
             self._apply_style()
+            self._apply_font_size()
 
     def _restore_prev(self) -> None:
         text = self.version_manager.undo()


### PR DESCRIPTION
## Summary
- allow setting base font size via new `font_size` setting
- expose font size in settings dialog
- apply font size across main UI

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689da4386e3c83329c8a89e409f3ee37