### PR TITLE
Fix Qt 6 orientation and remove unsupported style rule

### DIFF
--- a/app/styles.py
+++ b/app/styles.py
@@ -38,16 +38,22 @@ QTableWidget#glossary:hover {{
 
 
 def neon_glow_rule(color: str, intensity: int) -> str:
-    """Return a QSS snippet that adds an outer "neon" glow.
+    """Return a QSS snippet that highlights widgets on focus/hover.
+
+    Qt's style engine does not support the CSS ``box-shadow`` property.
+    Instead we approximate a glow effect by increasing the border thickness
+    relative to *intensity*. This avoids runtime warnings about unknown
+    properties while still providing visual feedback.
 
     Parameters
     ----------
     color:
         Hex representation of the glow colour.
     intensity:
-        Blur radius of the glow in pixels.
+        Desired glow intensity; mapped to border width.
     """
 
+    border_width = max(1, intensity // 2)
     return f"""
 QTextEdit:focus,
 QTextEdit:hover,
@@ -55,8 +61,7 @@ QLineEdit:focus,
 QLineEdit:hover,
 QTableWidget#glossary:focus,
 QTableWidget#glossary:hover {{
-    border: 1px solid {color};
-    box-shadow: 0 0 {intensity}px {color};
+    border: {border_width}px solid {color};
 }}
 """.strip()
 

--- a/app/ui_main.py
+++ b/app/ui_main.py
@@ -98,7 +98,7 @@ class Ui_MainWindow(object):
 
         # Splitter separating original and translation
         self.h_splitter = QtWidgets.QSplitter(
-            QtCore.Qt.Horizontal, parent=self.centralwidget
+            QtCore.Qt.Orientation.Horizontal, parent=self.centralwidget
         )
         self.main_layout.addWidget(self.h_splitter)
 


### PR DESCRIPTION
## Summary
- replace `QtCore.Qt.Horizontal` with `QtCore.Qt.Orientation.Horizontal`
- drop unsupported `box-shadow` in `neon_glow_rule`

## Testing
- `QT_QPA_PLATFORM=offscreen timeout 5 python -m app.main`


------
https://chatgpt.com/codex/tasks/task_e_689d90f566ec8332bb222842a9b87354