### PR TITLE
Handle startup errors with stack trace in run.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,6 +1,7 @@
 import importlib
 import subprocess
 import sys
+import traceback
 
 REQUIRED_PACKAGES = {
     "PyQt6": "PyQt6",
@@ -17,5 +18,9 @@ def ensure_packages() -> None:
 
 if __name__ == "__main__":
     ensure_packages()
-    from app.main import main
-    main()
+    try:
+        from app.main import main
+        main()
+    except Exception:
+        traceback.print_exc()
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- wrap the import and execution of `app.main` in a try/except
- print a stack trace and exit with code 1 when startup fails

## Testing
- `python -m py_compile run.py`
- `python run.py && echo OK` *(fails as expected when `app` is missing, printing stack trace)*

------
https://chatgpt.com/codex/tasks/task_e_689dd8bc88108332b8b7b62043914492