### PR TITLE
feat: add project context and metadata collection

### DIFF
--- a/app/services/project.py
+++ b/app/services/project.py
@@ -1,0 +1,98 @@
+"""Project management and metadata collection utilities."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import List, Dict
+
+from docx import Document
+
+
+@dataclass
+class Project:
+    """Representation of a translation project."""
+
+    id: str
+    title: str
+    chapters: list[dict] = field(default_factory=list)
+
+
+def _extract_metadata(text: str) -> Dict[str, List[str] | str]:
+    """Very lightweight metadata extraction from *text*.
+
+    The implementation uses simple heuristics to collect capitalised words as
+    potential names. Other fields are left empty for further manual refinement
+    or future improvements.
+    """
+
+    words = [w.strip(".,!?;:\"'()[]") for w in text.split()]
+    names = sorted({w for w in words if w.istitle()})
+    summary = text.splitlines()[0][:200] if text else ""
+    return {
+        "names": names,
+        "locations": [],
+        "characters": [],
+        "summary": summary,
+        "notes": "",
+    }
+
+
+class ProjectManager:
+    """Load and save :class:`Project` instances."""
+
+    def __init__(self, base_dir: Path | str = Path("data/projects")) -> None:
+        self.base_dir = Path(base_dir)
+
+    # ------------------------------------------------------------------
+    def load(self, project_id: str, title: str | None = None) -> Project:
+        """Load project metadata from disk or create a new project."""
+
+        project_dir = self.base_dir / project_id
+        path = project_dir / "project.json"
+        if path.exists():
+            with path.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            return Project(**data)
+        return Project(id=project_id, title=title or project_id)
+
+    # ------------------------------------------------------------------
+    def save(self, project: Project) -> None:
+        """Persist *project* metadata to JSON."""
+
+        project_dir = self.base_dir / project.id
+        project_dir.mkdir(parents=True, exist_ok=True)
+        path = project_dir / "project.json"
+        with path.open("w", encoding="utf-8") as fh:
+            json.dump(asdict(project), fh, ensure_ascii=False, indent=2)
+
+    # ------------------------------------------------------------------
+    def add_chapter(self, project: Project, name: str, text: str) -> None:
+        """Append a chapter entry and save associated files."""
+
+        meta = _extract_metadata(text)
+        project.chapters.append({"name": name, **meta})
+        self._save_chapter_docx(project.id, name, text)
+        self.save(project)
+
+    # ------------------------------------------------------------------
+    def _save_chapter_docx(self, project_id: str, name: str, text: str) -> None:
+        """Persist chapter *text* to a DOCX file using ``python-docx``."""
+
+        project_dir = self.base_dir / project_id
+        project_dir.mkdir(parents=True, exist_ok=True)
+        file_path = project_dir / f"{name}.docx"
+        doc = Document()
+        for paragraph in text.splitlines():
+            doc.add_paragraph(paragraph)
+        doc.save(file_path)
+
+    # ------------------------------------------------------------------
+    def overview(self, project: Project, upto: int) -> str:
+        """Return a short summary of chapters before index ``upto``."""
+
+        parts: list[str] = []
+        for chapter in project.chapters[:upto]:
+            parts.append(f"{chapter['name']}: {chapter.get('summary', '')}")
+        return "\n".join(parts)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyQt6
 google-api-python-client
 requests
+python-docx


### PR DESCRIPTION
## Summary
- add project manager with chapter metadata and docx storage
- integrate project context loading and chapter metadata saving
- require python-docx for chapter exports

## Testing
- `pip install python-docx > /tmp/pip.log && tail -n 20 /tmp/pip.log`
- `python -m py_compile app/services/project.py app/main.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_689f210fbbf08332a776c908b6972e14