### PR TITLE
chore: drop unsupported box-shadow reference

### DIFF
--- a/app/styles.py
+++ b/app/styles.py
@@ -42,8 +42,9 @@ QPushButton:hover {{
 def neon_glow_rule(color: str, intensity: int, width: int) -> str:
     """Return a QSS snippet that highlights widgets on focus/hover.
 
-    Qt's style engine does not support the CSS ``box-shadow`` property.
-    Instead we approximate a glow effect by increasing the border thickness.
+    Qt's style engine lacks native drop-shadow effects.  A simple way to
+    provide a visual highlight is to increase the border thickness, which
+    we use here to emulate a glow.
 
     Parameters
     ----------


### PR DESCRIPTION
## Summary
- clean up neon_glow_rule docstring to avoid referencing unsupported CSS box-shadow

## Testing
- `QT_QPA_PLATFORM=offscreen timeout 5s python run.py` *(fails: libpng warnings, KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_689f29f1a4688332ba8b014160f7145b