### PR TITLE
feat: configure Qt backend automatically

### DIFF
--- a/run.py
+++ b/run.py
@@ -17,12 +17,22 @@ def ensure_packages() -> None:
         except Exception:
             subprocess.check_call([sys.executable, "-m", "pip", "install", package])
 
+
+def configure_qt_platform() -> None:
+    """Configure Qt backend based on environment and system platform."""
+    platform = os.environ.get("QT_QPA_PLATFORM")
+    if platform == "offscreen":
+        del os.environ["QT_QPA_PLATFORM"]
+        platform = None
+        print("Предупреждение: QT_QPA_PLATFORM=offscreen удалён.")
+    if platform is None:
+        platform = "windows" if sys.platform.startswith("win") else "xcb"
+        os.environ["QT_QPA_PLATFORM"] = platform
+        print(f"Предупреждение: выбран бэкенд '{platform}'.")
+
 if __name__ == "__main__":
-    if os.environ.get("QT_QPA_PLATFORM") == "offscreen":
-        print(
-            "GUI не будет показан, удалите QT_QPA_PLATFORM или установите в windows"
-        )
     ensure_packages()
+    configure_qt_platform()
     try:
         from app.main import main
         main()


### PR DESCRIPTION
## Summary
- add function to select Qt backend based on platform and environment
- call backend configuration before importing application entry point

## Testing
- `python -m py_compile run.py`
- `python - <<'PY'
import os
import importlib
run = importlib.reload(__import__('run'))

# Test when QT_QPA_PLATFORM is 'offscreen'
os.environ['QT_QPA_PLATFORM']='offscreen'
run.configure_qt_platform()
print('env after offscreen:', os.environ.get('QT_QPA_PLATFORM'))

# Test when QT_QPA_PLATFORM is missing
os.environ.pop('QT_QPA_PLATFORM', None)
run.configure_qt_platform()
print('env after missing:', os.environ.get('QT_QPA_PLATFORM'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_689f31c7381883329afb83b2076fa618