### PR TITLE
Defer version history saves until explicit flush

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -356,6 +356,7 @@ class MainController:
         self.stats = append_stat(stat, self.stats_path)
         self.project_manager.add_chapter(self.project, name, text)
         self.ui.reset_timer()
+        self.ui.version_manager.flush()
         if self.settings.auto_next:
             self.next_chapter()
 
@@ -399,6 +400,7 @@ def main() -> None:
     ui.setupUi(window, settings)
     controller = MainController(window, ui, settings)
     app.aboutToQuit.connect(settings.save)
+    app.aboutToQuit.connect(ui.version_manager.flush)
     window.show()
     sys.exit(app.exec())
 

--- a/app/services/versioning.py
+++ b/app/services/versioning.py
@@ -32,14 +32,12 @@ class VersionManager:
         del self.versions[self.index + 1 :]
         self.versions.append({"timestamp": datetime.utcnow().isoformat(), "text": text})
         self.index = len(self.versions) - 1
-        save_versions(self.versions, self.path)
 
     def undo(self) -> str | None:
         """Step back in history and return the previous text."""
 
         if self.index > 0:
             self.index -= 1
-            save_versions(self.versions, self.path)
             return self.versions[self.index]["text"]
         return None
 
@@ -48,9 +46,12 @@ class VersionManager:
 
         if self.index < len(self.versions) - 1:
             self.index += 1
-            save_versions(self.versions, self.path)
             return self.versions[self.index]["text"]
         return None
+
+    def flush(self) -> None:
+        """Persist the current version history to disk."""
+        save_versions(self.versions, self.path)
 
 
 def check_for_updates(repo_path: Path) -> bool:


### PR DESCRIPTION
## Summary
- stop VersionManager from writing to disk on every change
- add `flush()` to VersionManager and invoke it on save and application exit

## Testing
- `python -m py_compile app/services/versioning.py app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_689f3aa440648332a84e3fd0bf7c32e7