### PR TITLE
Adjust main layout stretch for splitter and mini prompt

### DIFF
--- a/app/ui_main.py
+++ b/app/ui_main.py
@@ -319,7 +319,8 @@ class Ui_MainWindow(object):
         self.main_splitter.addWidget(self.v_splitter)
         self.main_splitter.addWidget(self.glossary_widget)
         self.main_layout.addWidget(self.main_splitter)
-        self.main_layout.setStretch(1, 1)
+        self.main_layout.setStretch(1, 1)  # splitter fills space
+        self.main_layout.setStretch(2, 0)  # mini-prompt keeps minimal height
         self._splitter_sizes = self.main_splitter.sizes()
 
         self.glossary_combo.currentIndexChanged.connect(self._on_glossary_selected)


### PR DESCRIPTION
## Summary
- Ensure the main splitter expands while the mini prompt keeps minimal height
- Confirm mini prompt is placed within a vertical splitter for resizable height

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a04727095c8332b523a6b5ed39e5a3