### PR TITLE
feat: add hover and focus styles for buttons

### DIFF
--- a/app/styles.py
+++ b/app/styles.py
@@ -30,10 +30,10 @@ QTextEdit:focus,
 QTextEdit:hover,
 QLineEdit:focus,
 QLineEdit:hover,
-QTableView#glossary:focus,
-QTableView#glossary:hover,
 QPushButton:focus,
-QPushButton:hover {{
+QPushButton:hover,
+QTableView#glossary:focus,
+QTableView#glossary:hover {{
     border: 1px solid {color};
 }}
 """.strip()
@@ -61,10 +61,10 @@ QTextEdit:focus,
 QTextEdit:hover,
 QLineEdit:focus,
 QLineEdit:hover,
-QTableView#glossary:focus,
-QTableView#glossary:hover,
 QPushButton:focus,
-QPushButton:hover {{
+QPushButton:hover,
+QTableView#glossary:focus,
+QTableView#glossary:hover {{
     border: {width}px solid {color};
 }}
 """.strip()

--- a/app/ui_main.py
+++ b/app/ui_main.py
@@ -414,6 +414,8 @@ class Ui_MainWindow(object):
         QPushButton {{
             padding: 2px 6px;
             min-height: 20px;
+            border: 1px solid transparent;
+            border-radius: 6px;
         }}
         {focus_rule}
         {glow_rule}


### PR DESCRIPTION
## Summary
- include QPushButton focus/hover selectors in `focus_hover_rule` and `neon_glow_rule`
- give buttons a transparent border so style rules affect them

## Testing
- `python -m py_compile app/styles.py app/ui_main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a04e29fb088332a84590aa5f20eb95