### PR TITLE
docs: clarify neon width handling

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -372,6 +372,7 @@ class SettingsDialog(QtWidgets.QDialog):
         self.neon_width_spin = QtWidgets.QSpinBox()
         self.neon_width_spin.setRange(1, 50)
         self.neon_width_spin.setValue(settings.neon_width)
+        self.neon_width_spin.setSuffix(" px")
 
         self.neon_preview = QtWidgets.QFrame()
         self.neon_preview.setFixedSize(40, 20)

--- a/app/styles.py
+++ b/app/styles.py
@@ -50,11 +50,13 @@ def neon_glow_rule(color: str, intensity: int, width: int) -> str:
     color:
         Hex representation of the glow colour.
     intensity:
-        Desired glow intensity (reserved for future use).
+        Desired glow intensity (currently unused).
     width:
         Border width for the glow effect.
     """
 
+    # ``intensity`` is kept for backward compatibility; only ``width``
+    # influences the resulting border thickness at the moment.
     selectors = [
         "QTextEdit:focus",
         "QTextEdit:hover",

--- a/app/ui_main.py
+++ b/app/ui_main.py
@@ -379,7 +379,7 @@ class Ui_MainWindow(object):
         glow_rule = styles.neon_glow_rule(
             self.settings.neon_color,
             self.settings.neon_intensity,
-            self.settings.neon_width,
+            self.settings.neon_width,  # configurable border width
         )
         focus_rule = styles.focus_hover_rule(self.settings.accent_color)
         style_sheet = f"""


### PR DESCRIPTION
## Summary
- document `neon_glow_rule` width parameter and note that intensity is currently unused
- show pixel suffix for configurable neon width in settings dialog
- annotate style application with neon width comment

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a061c4ead083329687cb030d945cda