### PR TITLE
feat: allow font customization

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -60,6 +60,10 @@ class AppSettings:
         Accent colour for focused elements.
     text_color:
         Default text colour for widgets.
+    header_font:
+        Font family used for headers and menus.
+    base_font:
+        Font family used for editable text and tables.
     font_size:
         Base font size for text areas and tables.
     neon_color:
@@ -98,6 +102,8 @@ class AppSettings:
     app_background: str = styles.APP_BACKGROUND
     accent_color: str = styles.ACCENT_COLOR
     text_color: str = styles.TEXT_COLOR
+    header_font: str = styles.HEADER_FONT
+    base_font: str = styles.INTER_FONT
     neon_color: str = styles.ACCENT_COLOR
     neon_intensity: int = 20
     neon_width: int = 10
@@ -136,6 +142,8 @@ class AppSettings:
         qs.setValue("app_background", self.app_background)
         qs.setValue("accent_color", self.accent_color)
         qs.setValue("text_color", self.text_color)
+        qs.setValue("header_font", self.header_font)
+        qs.setValue("base_font", self.base_font)
         qs.setValue("font_size", self.font_size)
         qs.setValue("neon_color", self.neon_color)
         qs.setValue("neon_intensity", self.neon_intensity)
@@ -174,6 +182,8 @@ class AppSettings:
             app_background=qs.value("app_background", styles.APP_BACKGROUND, str),
             accent_color=qs.value("accent_color", styles.ACCENT_COLOR, str),
             text_color=qs.value("text_color", styles.TEXT_COLOR, str),
+            header_font=qs.value("header_font", styles.HEADER_FONT, str),
+            base_font=qs.value("base_font", styles.INTER_FONT, str),
             font_size=qs.value("font_size", 10, int),
             neon_color=qs.value("neon_color", styles.ACCENT_COLOR, str),
             neon_intensity=qs.value("neon_intensity", 20, int),
@@ -409,6 +419,14 @@ class SettingsDialog(QtWidgets.QDialog):
         text_layout.addWidget(self.text_color_btn)
         layout.addRow("Цвет текста", text_layout)
 
+        self.header_font_combo = QtWidgets.QFontComboBox()
+        self.header_font_combo.setCurrentFont(QtGui.QFont(settings.header_font))
+        layout.addRow("Шрифт заголовков", self.header_font_combo)
+
+        self.base_font_combo = QtWidgets.QFontComboBox()
+        self.base_font_combo.setCurrentFont(QtGui.QFont(settings.base_font))
+        layout.addRow("Базовый шрифт", self.base_font_combo)
+
         self.font_size_spin = QtWidgets.QSpinBox()
         self.font_size_spin.setRange(6, 48)
         self.font_size_spin.setValue(settings.font_size)
@@ -626,6 +644,8 @@ class SettingsDialog(QtWidgets.QDialog):
         self.settings.app_background = self.app_bg_edit.text()
         self.settings.accent_color = self.accent_color_edit.text()
         self.settings.text_color = self.text_color_edit.text()
+        self.settings.header_font = self.header_font_combo.currentFont().family()
+        self.settings.base_font = self.base_font_combo.currentFont().family()
         self.settings.highlight_color = self._color.name(
             QtGui.QColor.NameFormat.HexArgb
         )

--- a/app/styles.py
+++ b/app/styles.py
@@ -86,17 +86,18 @@ def init(settings: Any | None = None) -> None:
 
     global APP_BACKGROUND, ACCENT_COLOR, TEXT_COLOR, INTER_FONT, HEADER_FONT
 
+    # Register bundled fonts so they are available in font pickers
+    if family := _register_font("Inter-VariableFont_opsz,wght.ttf"):
+        INTER_FONT = family
+
+    header_family = _register_font("Cattedrale[RUSbypenka220]-Regular.ttf")
+    if not header_family:
+        raise RuntimeError("Failed to load Cattedrale[RUSbypenka220]-Regular.ttf")
+    HEADER_FONT = header_family
+
     if settings is not None:
         APP_BACKGROUND = getattr(settings, "app_background", APP_BACKGROUND)
         ACCENT_COLOR = getattr(settings, "accent_color", ACCENT_COLOR)
         TEXT_COLOR = getattr(settings, "text_color", TEXT_COLOR)
-
-    # Register the Inter font for main text
-    if family := _register_font("Inter-VariableFont_opsz,wght.ttf"):
-        INTER_FONT = family
-
-    # Register the Cattedrale font for headers
-    family = _register_font("Cattedrale[RUSbypenka220]-Regular.ttf")
-    if not family:
-        raise RuntimeError("Failed to load Cattedrale[RUSbypenka220]-Regular.ttf")
-    HEADER_FONT = family
+        INTER_FONT = getattr(settings, "base_font", INTER_FONT)
+        HEADER_FONT = getattr(settings, "header_font", HEADER_FONT)

--- a/app/ui_main.py
+++ b/app/ui_main.py
@@ -134,12 +134,12 @@ class Ui_MainWindow(object):
 
         # Menu bar
         self.menu_bar = MainWindow.menuBar()
-        self.menu_bar.setFont(QtGui.QFont(styles.HEADER_FONT, 10))
+        self.menu_bar.setFont(QtGui.QFont(self.settings.header_font, 10))
         self.settings_menu = self.menu_bar.addMenu("")
-        self.settings_menu.setFont(QtGui.QFont(styles.HEADER_FONT, 10))
+        self.settings_menu.setFont(QtGui.QFont(self.settings.header_font, 10))
         self.settings_action = QtGui.QAction(parent=MainWindow)
         self.settings_action.setIcon(QIcon(resource_path("настройки.png")))
-        self.settings_action.setFont(QtGui.QFont(styles.HEADER_FONT, 10))
+        self.settings_action.setFont(QtGui.QFont(self.settings.header_font, 10))
         self.settings_menu.addAction(self.settings_action)
         self.settings_action.triggered.connect(self._open_settings)
 
@@ -337,17 +337,17 @@ class Ui_MainWindow(object):
         self.status_layout.setSpacing(4)
         self.status_layout.addStretch()
         self.version_label = QtWidgets.QLabel(__version__, parent=self.centralwidget)
-        self.version_label.setFont(QtGui.QFont(styles.HEADER_FONT, 10))
+        self.version_label.setFont(QtGui.QFont(self.settings.header_font, 10))
         self.status_layout.addWidget(self.version_label)
         self.timer_label = QtWidgets.QLabel("00:00:00", parent=self.centralwidget)
-        self.timer_label.setFont(QtGui.QFont(styles.HEADER_FONT, 10))
+        self.timer_label.setFont(QtGui.QFont(self.settings.header_font, 10))
         self.status_layout.addWidget(self.timer_label)
         self.main_layout.addLayout(self.status_layout)
         self.main_layout.setStretch(3, 1)  # splitter fills remaining space
         self.main_layout.setStretch(4, 0)  # status bar keeps minimal height
 
         # Fonts
-        base_font = QtGui.QFont(styles.INTER_FONT, self.settings.font_size)
+        base_font = QtGui.QFont(self.settings.base_font, self.settings.font_size)
         self.original_edit.setFont(base_font)
         self.translation_edit.setFont(base_font)
         self.mini_prompt_edit.setFont(base_font)
@@ -386,7 +386,7 @@ class Ui_MainWindow(object):
         QWidget {{
             background-color: {self.settings.app_background};
             color: {self.settings.text_color};
-            font-family: {styles.INTER_FONT};
+            font-family: {self.settings.base_font};
         }}
         QTextEdit,
         QLineEdit {{
@@ -416,11 +416,17 @@ class Ui_MainWindow(object):
         self.centralwidget.setStyleSheet(style_sheet)
 
     def _apply_font_size(self) -> None:
-        base_font = QtGui.QFont(styles.INTER_FONT, self.settings.font_size)
+        base_font = QtGui.QFont(self.settings.base_font, self.settings.font_size)
         self.original_edit.setFont(base_font)
         self.translation_edit.setFont(base_font)
         self.mini_prompt_edit.setFont(base_font)
         self.glossary_table.setFont(base_font)
+        header_font = QtGui.QFont(self.settings.header_font, 10)
+        self.menu_bar.setFont(header_font)
+        self.settings_menu.setFont(header_font)
+        self.settings_action.setFont(header_font)
+        self.version_label.setFont(header_font)
+        self.timer_label.setFont(header_font)
 
     # --- internal helpers -------------------------------------------------
     def _update_timer(self) -> None:


### PR DESCRIPTION
## Summary
- allow choosing header and base fonts in settings
- persist selected fonts and apply them throughout the UI

## Testing
- `python -m py_compile app/settings.py app/styles.py app/ui_main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0643c8f20833283aefdd88d357a5c