### PR TITLE
feat: add proxy support to API clients

### DIFF
--- a/app/models/grok.py
+++ b/app/models/grok.py
@@ -6,6 +6,9 @@ from typing import Dict, Optional
 import json
 from urllib import error, request
 
+from ..services.http import create_opener
+from ..settings import AppSettings
+
 
 class GrokTranslator:
     """Translate text using xAI's Grok model."""
@@ -13,11 +16,14 @@ class GrokTranslator:
     BASE_URL = "https://api.x.ai/v1/chat/completions"
     DEFAULT_MODEL = "grok-beta"
 
-    def __init__(self, api_key: str, model: str | None = None) -> None:
+    def __init__(
+        self, api_key: str, model: str | None = None, *, settings: AppSettings | None = None
+    ) -> None:
         self.api_key = api_key
         if not self.api_key:
             raise ValueError("Grok API key not provided")
         self.model = model or self.DEFAULT_MODEL
+        self._opener = create_opener(settings)
 
     # ------------------------------------------------------------------
     def translate(
@@ -55,7 +61,7 @@ class GrokTranslator:
         )
 
         try:
-            with request.urlopen(req) as resp:
+            with self._opener.open(req) as resp:
                 payload = json.loads(resp.read().decode("utf-8"))
         except error.HTTPError as exc:  # pragma: no cover - network/IO safety
             message = exc.read().decode("utf-8", errors="ignore")

--- a/app/models/qwen.py
+++ b/app/models/qwen.py
@@ -6,6 +6,9 @@ from typing import Dict, Optional
 import json
 from urllib import error, request
 
+from ..services.http import create_opener
+from ..settings import AppSettings
+
 
 class QwenTranslator:
     """Translate text using the Qwen model."""
@@ -13,11 +16,14 @@ class QwenTranslator:
     BASE_URL = "https://api.qwen.ai/v1/chat/completions"
     DEFAULT_MODEL = "qwen-turbo"
 
-    def __init__(self, api_key: str, model: str | None = None) -> None:
+    def __init__(
+        self, api_key: str, model: str | None = None, *, settings: AppSettings | None = None
+    ) -> None:
         self.api_key = api_key
         if not self.api_key:
             raise ValueError("Qwen API key not provided")
         self.model = model or self.DEFAULT_MODEL
+        self._opener = create_opener(settings)
 
     # ------------------------------------------------------------------
     def translate(
@@ -54,7 +60,7 @@ class QwenTranslator:
         )
 
         try:
-            with request.urlopen(req) as resp:
+            with self._opener.open(req) as resp:
                 payload = json.loads(resp.read().decode("utf-8"))
         except error.HTTPError as exc:  # pragma: no cover - network/IO safety
             message = exc.read().decode("utf-8", errors="ignore")

--- a/app/services/http.py
+++ b/app/services/http.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from urllib import request as urllib_request
+
 import requests
 
 from ..settings import AppSettings
@@ -22,3 +24,15 @@ def create_session(settings: AppSettings | None = None) -> requests.Session:
             "https": settings.proxy_url,
         })
     return session
+
+
+def create_opener(settings: AppSettings | None = None) -> urllib_request.OpenerDirector:
+    """Return a :class:`urllib.request.OpenerDirector` respecting proxy settings."""
+
+    settings = settings or AppSettings.load()
+    if getattr(settings, "use_proxy", False) and getattr(settings, "proxy_url", ""):
+        handler = urllib_request.ProxyHandler(
+            {"http": settings.proxy_url, "https": settings.proxy_url}
+        )
+        return urllib_request.build_opener(handler)
+    return urllib_request.build_opener()

--- a/app/settings.py
+++ b/app/settings.py
@@ -528,15 +528,15 @@ class SettingsDialog(QtWidgets.QDialog):
             elif name == "deepl":
                 from .models.deepl import DeepLTranslator
 
-                DeepLTranslator(key).translate("ping")
+                DeepLTranslator(key, settings=self.settings).translate("ping")
             elif name == "grok":
                 from .models.grok import GrokTranslator
 
-                GrokTranslator(key).translate("ping")
+                GrokTranslator(key, settings=self.settings).translate("ping")
             elif name == "qwen":
                 from .models.qwen import QwenTranslator
 
-                QwenTranslator(key).translate("ping")
+                QwenTranslator(key, settings=self.settings).translate("ping")
             success = True
         except Exception:
             success = False


### PR DESCRIPTION
## Summary
- add HTTP opener helper to apply user proxy settings
- honour proxy configuration in DeepL, Grok and Qwen API clients
- respect proxy settings when validating API keys

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0681cfca083329764fde75709ddcf