### PR TITLE
Derive app version from git commit count

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,9 +7,17 @@ import subprocess
 
 def get_version() -> str:
     """Return application version ``0.1.<commit_count>``."""
-    commit_count = subprocess.check_output(
-        ["git", "rev-list", "--count", "HEAD"], text=True
-    ).strip()
+    try:
+        result = subprocess.run(
+            ["git", "rev-list", "--count", "HEAD"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=True,
+        )
+        commit_count = result.stdout.strip()
+    except (subprocess.SubprocessError, FileNotFoundError):
+        commit_count = "0"
     return f"0.1.{commit_count}"
 
 

--- a/app/ui_main.py
+++ b/app/ui_main.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from PyQt6 import QtCore, QtGui, QtWidgets
 from PyQt6.QtGui import QIcon, QStandardItem, QStandardItemModel
 
-from . import __version__, styles
+from . import styles, __version__
 from .services.versioning import VersionManager
 from .services.morphology import MorphologyService, MorphologyHighlighter
 from .services.glossary import (
@@ -332,6 +332,7 @@ class Ui_MainWindow(object):
         self.status_layout.setContentsMargins(0, 0, 0, 0)
         self.status_layout.setSpacing(4)
         self.status_layout.addStretch()
+        # Display application version retrieved from ``app.__version__``
         self.version_label = QtWidgets.QLabel(__version__, parent=self.centralwidget)
         self.version_label.setFont(QtGui.QFont(self.settings.header_font, 10))
         self.status_layout.addWidget(self.version_label)


### PR DESCRIPTION
## Summary
- compute application version using `git rev-list --count` and expose via `__version__`
- show derived version in the UI's status bar

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0806c5c3883329e455205647426b1