### PR TITLE
Add project tree folders and summary export

### DIFF
--- a/app/services/project.py
+++ b/app/services/project.py
@@ -102,3 +102,16 @@ class ProjectManager:
         for chapter in project.chapters[:upto]:
             parts.append(f"{chapter.name}: {chapter.plot}")
         return "\n".join(parts)
+
+    # ------------------------------------------------------------------
+    def export_summary(self, project: Project) -> Path:
+        """Export project overview to a DOCX file and return the path."""
+
+        project_dir = self.base_dir / project.id
+        project_dir.mkdir(parents=True, exist_ok=True)
+        path = project_dir / "summary.docx"
+        doc = Document()
+        for line in self.overview(project, len(project.chapters)).splitlines():
+            doc.add_paragraph(line)
+        doc.save(path)
+        return path


### PR DESCRIPTION
## Summary
- Label project tree with "Активные проекты" and "Архив" categories and hide header
- Add context menu action to export project summary to DOCX
- Provide project service helper to write project overviews to DOCX

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a17bd480288332a84b224b45e7af2e