### PR TITLE
Configure Qt backend before launching app

### DIFF
--- a/run.py
+++ b/run.py
@@ -24,11 +24,8 @@ def configure_qt_platform() -> None:
     if platform == "offscreen":
         del os.environ["QT_QPA_PLATFORM"]
         platform = None
-        print("Предупреждение: QT_QPA_PLATFORM=offscreen удалён.")
     if platform is None:
-        platform = "windows" if sys.platform.startswith("win") else "xcb"
-        os.environ["QT_QPA_PLATFORM"] = platform
-        print(f"Предупреждение: выбран бэкенд '{platform}'.")
+        os.environ["QT_QPA_PLATFORM"] = "windows" if sys.platform.startswith("win") else "xcb"
 
 if __name__ == "__main__":
     ensure_packages()


### PR DESCRIPTION
## Summary
- ensure the Qt platform backend is set to a suitable default
- call the backend configuration after verifying required packages

## Testing
- `python -m py_compile run.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a17f9b7d048332826fee27165f582e