### PR TITLE
Compute version from git commit count and show in UI

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,18 +6,27 @@ import subprocess
 
 
 def get_version() -> str:
-    """Return application version ``0.1.<commit_count>``."""
+    """Return application version ``1.1 + merges*0.1``.
+
+    The version is calculated from the number of commits in the repository.
+    Each commit increases the version by ``0.1`` starting from ``1.1``.
+    ``git`` is queried via ``git rev-list --count HEAD``; if that command
+    fails, ``1.1`` is returned.
+    """
+
     try:
-        commit_count = (
+        merges = int(
             subprocess.check_output(
                 ["git", "rev-list", "--count", "HEAD"], stderr=subprocess.DEVNULL
             )
             .decode()
             .strip()
         )
-    except (subprocess.SubprocessError, FileNotFoundError):
-        commit_count = "0"
-    return f"0.1.{commit_count}"
+    except (subprocess.SubprocessError, FileNotFoundError, ValueError):
+        merges = 0
+
+    version = 1.1 + merges * 0.1
+    return f"{version:.1f}"
 
 
 __version__ = get_version()

--- a/app/ui_main.py
+++ b/app/ui_main.py
@@ -888,7 +888,9 @@ class Ui_MainWindow(object):
     # --- translations -----------------------------------------------------
     def retranslateUi(self, MainWindow):
         _translate = QtCore.QCoreApplication.translate
-        MainWindow.setWindowTitle(_translate("MainWindow", "Main Window"))
+        MainWindow.setWindowTitle(
+            _translate("MainWindow", "Main Window") + f" v{__version__}"
+        )
         self.prev_btn.setText(_translate("MainWindow", "⦉"))
         self.next_btn.setText(_translate("MainWindow", "⦊"))
         self.save_btn.setText(_translate("MainWindow", "Сохранить"))


### PR DESCRIPTION
## Summary
- derive application version from `git rev-list --count HEAD`
- show application version in main window title

## Testing
- `pytest`
- `python -m py_compile app/__init__.py app/ui_main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a18f5d35e48332858aba27b08f309b