### PR TITLE
Add docx runtime dependency

### DIFF
--- a/run.py
+++ b/run.py
@@ -7,14 +7,13 @@ import traceback
 REQUIRED_PACKAGES = {
     "PyQt6": "PyQt6",
     "googleapiclient": "google-api-python-client",
+    "docx": "python-docx",
 }
 
 def ensure_packages() -> None:
     """Install required packages if they are missing."""
     for module, package in REQUIRED_PACKAGES.items():
-        try:
-            importlib.import_module(module)
-        except Exception:
+        if importlib.util.find_spec(module) is None:
             subprocess.check_call([sys.executable, "-m", "pip", "install", package])
 
 


### PR DESCRIPTION
## Summary
- include `docx` mapped to `python-docx` in required packages
- use `importlib.util.find_spec` to detect missing modules before pip installation

## Testing
- `python -m py_compile run.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac97f70234833299cee33d2b61b0c0