### PR TITLE
Wrap package check for third-party importlib conflicts

### DIFF
--- a/run.py
+++ b/run.py
@@ -13,8 +13,16 @@ REQUIRED_PACKAGES = {
 def ensure_packages() -> None:
     """Install required packages if they are missing."""
     for module, package in REQUIRED_PACKAGES.items():
-        if importlib.util.find_spec(module) is None:
-            subprocess.check_call([sys.executable, "-m", "pip", "install", package])
+        try:
+            try:
+                __import__(module)
+            except ModuleNotFoundError:
+                subprocess.check_call([sys.executable, "-m", "pip", "install", package])
+        except AttributeError:
+            # A third-party "importlib" package can shadow the standard library module,
+            # leaving ``importlib.util`` unavailable.
+            if importlib.util.find_spec(module) is None:
+                subprocess.check_call([sys.executable, "-m", "pip", "install", package])
 
 
 def configure_qt_platform() -> None:


### PR DESCRIPTION
## Summary
- Guard package checks against third-party `importlib` shadowing
- Attempt to import modules directly before installing requirements

## Testing
- `python -m py_compile run.py && echo "py_compile success"`


------
https://chatgpt.com/codex/tasks/task_e_68ac9cd835ec83329420ec22bda554e7